### PR TITLE
DispatchPeers Functionality

### DIFF
--- a/cmd/pocket_core/main.go
+++ b/cmd/pocket_core/main.go
@@ -56,6 +56,7 @@ func startClient() {
 	config.BuildConfiguration()                                     			// builds the proper structure on pc for core client to operate.
 	config.PrintConfiguration()                                     			// print the configuration the the cmd.
 	peersFromFile()                                                   			// check for manual peers
+	node.GetPeerList().AddPeersToDispatchStructure()							// add peers to dispatch structure
 	chainsFromFile()															// check for chains.json file
 	logs.NewLog("Started client", logs.InfoLevel, logs.JSONLogFormat) 	// log start message
 	rpc.RunAPIEndpoints()                                           			// runs the server endpoints for client and relay api.

--- a/cmd/pocket_core/main.go
+++ b/cmd/pocket_core/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pokt-network/pocket-core/logs"
 	"github.com/pokt-network/pocket-core/message"
 	"github.com/pokt-network/pocket-core/node"
-	"github.com/pokt-network/pocket-core/peers"
 	"github.com/pokt-network/pocket-core/rpc"
 	"os"
 )
@@ -35,7 +34,7 @@ func main() {
 "manualPeers" parses peers from peers.json file
 */
 func peersFromFile() {
-	if err := peers.ManualPeersFile(config.GetConfigInstance().PeerFile); err!=nil { // add peers from file
+	if err := node.ManualPeersFile(config.GetConfigInstance().PeerFile); err!=nil { // add peers from file
 		// TODO handle error (note: if file doesn't exist this still should work)
 	}
 }

--- a/doc/sampleConfigFiles/chains.json
+++ b/doc/sampleConfigFiles/chains.json
@@ -1,4 +1,5 @@
 // Sample chain.json file. To use, place in data directory (REMOVE THIS COMMENT BEFORE USE)
+
 [
     {
         "blockchain": {

--- a/node/dispatch.go
+++ b/node/dispatch.go
@@ -1,0 +1,70 @@
+package node
+
+import (
+	"fmt"
+	"sync"
+)
+
+// This file holds a global structure used for dispatching
+// NOTE: currently this is developed for PC MVP Shift and may be phased out depending on performance and need
+
+var (
+	dispatchPeers map[Blockchain]map[string]Node	// <BlockchainOBJ><GID><Node>
+	m sync.Mutex
+	one sync.Once
+)
+
+func getDispatchPeers() map[Blockchain]map[string]Node{
+	one.Do(func() {
+		dispatchPeers = make(map[Blockchain]map[string]Node)
+	})
+	return dispatchPeers
+}
+
+
+func NewDispatchPeer(newNode Node){
+	m.Lock()
+	defer m.Unlock()
+	dispatchPeers := getDispatchPeers()
+	for _,blockchain := range newNode.Blockchains{
+		nodes := dispatchPeers[blockchain] // type map[GID]Node
+		if nodes == nil { // blockchain not within list
+			dispatchPeers[blockchain] = map[string]Node{newNode.GID:newNode}// add new node to empty map
+		}else{	// blockchain is within list
+			nodes[newNode.GID]=newNode // add node to inner map
+			dispatchPeers[blockchain] = nodes // update outer map
+		}
+	}
+}
+
+func getPeersByBlockchain(blockchain Blockchain) map[string]Node{
+	return getDispatchPeers()[blockchain]
+}
+
+func GetPeersByBlockchain(blockchain Blockchain) map[string]Node{
+	m.Lock()
+	defer m.Unlock()
+	return getPeersByBlockchain(blockchain)
+}
+
+
+func DeleteDispatchPeer(delNode Node) {
+	m.Lock()
+	defer m.Unlock()
+	for _, blockchain := range delNode.Blockchains{
+		delete(getPeersByBlockchain(blockchain),delNode.GID)	// delete node from map via GID
+	}
+}
+
+func PrintDispatchPeers(){
+	m.Lock()
+	defer m.Unlock()
+	for blockchain,nodeMap := range getDispatchPeers() {
+		fmt.Println(blockchain.Name,"Version:",blockchain.Version,"NetID:",blockchain.NetID)
+		fmt.Println("  GID's:")
+		for gid,_ := range nodeMap {
+			fmt.Println("   ",gid)
+		}
+		fmt.Println("")
+	}
+}

--- a/node/peerList.go
+++ b/node/peerList.go
@@ -93,6 +93,15 @@ func (pList *PeerList) Print() {
 	fmt.Println(pList.List)							// print the list to the console
 }
 
+// NOTE Centralized Dispatch for MVP Only
+func (pList *PeerList) AddPeersToDispatchStructure(){
+	pList.Lock()
+	defer pList.Unlock()
+	for _, peer := range pList.List {
+		NewDispatchPeer(peer)
+	}
+}
+
 /***********************************************************************************************************************
 peerList Functions
 */

--- a/node/peerList.go
+++ b/node/peerList.go
@@ -1,11 +1,10 @@
 // This package is network code relating to other nodes within the network.
-package peers
+package node
 
 import (
 	"encoding/json"
 	"fmt"
 	"github.com/pokt-network/pocket-core/logs"
-	"github.com/pokt-network/pocket-core/node"
 	"io/ioutil"
 	"sync"
 )
@@ -16,7 +15,7 @@ import (
 Peerlist structure
  */
 type PeerList struct {
-	List map[string]node.Node
+	List map[string]Node
 	sync.Mutex
 }
 
@@ -24,7 +23,7 @@ type PeerList struct {
 Peerlist instance
  */
 var (
-	once  sync.Once
+	o  sync.Once
 	pList *PeerList
 )
 
@@ -36,9 +35,9 @@ Singleton getter
 "GetPeerList" returns the global list of peers
  */
 func GetPeerList() *PeerList {
-	once.Do(func() {								// only do once (thread safety)
+	o.Do(func() {									// only do once (thread safety)
 		pList = &PeerList{}							// init empty peerlist
-		pList.List = make(map[string]node.Node) 	// make the map [GID]Node
+		pList.List = make(map[string]Node) 			// make the map [GID]Node
 	})
 	return pList									// return the peerlist
 }
@@ -50,7 +49,7 @@ peerList Methods
 /*
 "AddPeer" adds a peer object to the global peerlist
  */
-func (pList *PeerList) AddPeer(node node.Node) {
+func (pList *PeerList) AddPeer(node Node) {
 	if !pList.Contains(node.GID) { 					// if node not within peerlist
 		pList.Lock()								// lock the list
 		defer pList.Unlock()						// after function completes unlock the list
@@ -62,7 +61,7 @@ func (pList *PeerList) AddPeer(node node.Node) {
 /*
 "RemovePeer" removes a peer object from the global list
  */
-func (pList *PeerList) RemovePeer(node node.Node) {
+func (pList *PeerList) RemovePeer(node Node) {
 	pList.Lock()									// lock the list
 	defer pList.Unlock()							// after the function completes unlock the list
 	logs.NewLog("Removed peer: "+node.GID, logs.InfoLevel, logs.JSONLogFormat)
@@ -112,7 +111,7 @@ func ManualPeersFile(filepath string) error {
 "manualPeersJSON" adds peers from a json []byte to the peerlist
  */
 func manualPeersJSON(b []byte) error{
-	var data []node.Node							// create an empty structure to hold the data temporarily
+	var data []Node									// create an empty structure to hold the data temporarily
 	if err:=json.Unmarshal(b, &data); err != nil{	// unmarshal the byte array into the struct
 		return err
 	}

--- a/rpc/relay/dispatch.go
+++ b/rpc/relay/dispatch.go
@@ -6,7 +6,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/pokt-network/pocket-core/crypto"
 	"github.com/pokt-network/pocket-core/logs"
-	"github.com/pokt-network/pocket-core/peers"
 	"github.com/pokt-network/pocket-core/session"
 	"github.com/pokt-network/pocket-core/node"
 	"github.com/pokt-network/pocket-core/rpc/shared"
@@ -54,7 +53,7 @@ func DispatchServe(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 func DispatchFind(sessionKey string) []node.Node {
 	bigSessionKey := new(big.Int)           					// create new big integer to store sessionKey in
 	bigSessionKey.SetString(sessionKey, 16) 				// convert hex string into big integer
-	peerList := peers.GetPeerList()         					// get the global peerlist
+	peerList := node.GetPeerList()         						// get the global peerlist
 	peerList.Lock()                         					// TODO currently locking the peerlist, however this will all change when p2p is integerated
 	defer peerList.Unlock()
 	m := make(map[uint64]node.Node)                      		// map the nodes to the corresponding difference

--- a/session/sessionPeer.go
+++ b/session/sessionPeer.go
@@ -2,7 +2,6 @@
 package session
 
 import (
-	"github.com/pokt-network/pocket-core/peers"
 	"github.com/pokt-network/pocket-core/node"
 )
 
@@ -35,7 +34,7 @@ Session Peer Functions
 "AddSessionPeersToPeerList" adds sessionPeers from a slice to the peerlist
  */
 func AddSessPeersToPL(spl []SessionPeer) {
-	pl := peers.GetPeerList()			// get the peerlist
+	pl := node.GetPeerList()			// get the peerlist
 	for _, sp := range spl {			// for each SessionPeer
 		pl.AddPeer(sp.Node)				// add to the list
 	}
@@ -45,6 +44,6 @@ func AddSessPeersToPL(spl []SessionPeer) {
 "AddSessionPeerToPeerList" adds a single sessionPeer to the peerList
  */
 func AddSessionPeerToPeerlist(sp SessionPeer) {
-	pl := peers.GetPeerList()			// get the peerlist
+	pl := node.GetPeerList()			// get the peerlist
 	pl.AddPeer(sp.Node)					// add the peer to the list
 }

--- a/tests/message/Session_test.go
+++ b/tests/message/Session_test.go
@@ -38,11 +38,11 @@ func TestSessionMessage(t *testing.T) {
 		t.Fatalf("The session for "+ DEVID+" doesn't exist")
 	}
 	// check for any peers within the peerlist
-	if peers.GetPeerList().Count() == 0 {
+	if node.GetPeerList().Count() == 0 {
 		t.Fatalf("No peers within peerlist")
 	}
 	// check for the correct peers within the peerlist
-	if !peers.GetPeerList().Contains(SNODE) || !peers.GetPeerList().Contains(VNODE) {
+	if !node.GetPeerList().Contains(SNODE) || !node.GetPeerList().Contains(VNODE) {
 		t.Fatalf(SNODE + " and " + VNODE + " do not exist within peerlist")
 	}
 	session1=session.GetSessionList().Get(DEVID)

--- a/tests/node/DispatchPeers_test.go
+++ b/tests/node/DispatchPeers_test.go
@@ -1,0 +1,46 @@
+package node
+
+import (
+	"github.com/pokt-network/pocket-core/node"
+	"log"
+	"testing"
+)
+
+func TestDispatchPeers(t *testing.T) {
+	// create arbitrary blockchains
+	ethereum := node.Blockchain{"ethereum", "1", "1.0"}
+	rinkeby  := node.Blockchain{"ethereum","4", "1.0"}
+	bitcoin := node.Blockchain{"bitcoin","1","1.0"}
+	bitcoinv1 := node.Blockchain{"bitcoin","1","1.1"}
+	bitcoinCash := node.Blockchain{"bitcoinCash","1","1.0"}
+	// create arbitrary nodes
+	node1:= node.Node{
+		GID:"node1",
+		Blockchains:[]node.Blockchain{ethereum, rinkeby, bitcoin}}
+	node2:= node.Node{
+		GID:"node2",
+		Blockchains:[]node.Blockchain{ethereum, bitcoin, bitcoinv1}}
+	node3:= node.Node{
+		GID:"node3",
+		Blockchains:[]node.Blockchain{bitcoinCash, ethereum, bitcoin}}
+	// add them to dispatchPeers
+	node.NewDispatchPeer(node1)
+	node.NewDispatchPeer(node2)
+	node.NewDispatchPeer(node3)
+	// get node lists
+	ethereumNodes:= node.GetPeersByBlockchain(ethereum)
+	btcNodes:= node.GetPeersByBlockchain(bitcoin)
+	btcNodesV1:= node.GetPeersByBlockchain(bitcoinv1)
+	bchNodes := node.GetPeersByBlockchain(bitcoinCash)
+	rinkebyNodes := node.GetPeersByBlockchain(rinkeby)
+	// ensure each list has proper node count
+	if len(ethereumNodes)!=3 || len(btcNodes)!=3 ||len(rinkebyNodes)!=1 && len(btcNodesV1)!=1 && len(bchNodes)!=1{
+		log.Fatalf("Incorrect node count")
+	}
+	// ensure each node is on list
+	if ethereumNodes[node1.GID].GID=="" || ethereumNodes[node2.GID].GID=="" || ethereumNodes[node3.GID].GID=="" {
+		log.Fatalf("Missing nodes")
+	}
+	// print the dispatch peers for visibility
+	node.PrintDispatchPeers()
+}

--- a/tests/rpc/SessionKey_test.go
+++ b/tests/rpc/SessionKey_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/pokt-network/pocket-core/config"
-	"github.com/pokt-network/pocket-core/peers"
 	"github.com/pokt-network/pocket-core/node"
 	"github.com/pokt-network/pocket-core/rpc/relay"
 	"github.com/pokt-network/pocket-core/rpc/shared"
@@ -19,7 +18,7 @@ func TestSessionKey(t *testing.T) {
 	n2 := node.Node{GID:"211057e8a7bbf340614b55fce0c481f3da8179b2"}
 	n3 := node.Node{GID:"211057e8a7bbf340614b55fce0c481f3da8179b3"}
 	// add to peerList
-	pList := peers.GetPeerList()
+	pList := node.GetPeerList()
 	pList.AddPeer(n1)
 	pList.AddPeer(n2)
 	pList.AddPeer(n3)

--- a/tests/rpc/SessionKey_test.go
+++ b/tests/rpc/SessionKey_test.go
@@ -59,5 +59,5 @@ func TestSessionKey(t *testing.T) {
 	if data[1].GID != n2.GID { // Assert order
 		t.Fatalf("Nodes are not in correct order")
 	}
-	peers.GetPeerList().Print()
+	node.GetPeerList().Print()
 }


### PR DESCRIPTION
Dispatch Peers is a structure needed to dispatch service nodes by the specific blockchain:
````
type Blockchain struct {
	Name    string `json:"name"`
	NetID   string `json:"netid"`
	Version string `json:"version"`
}
````
Example:
Service Node hits centralized dispatcher with a request to be added to the "master list"
After passing a _//todo white list check_ the service node is entered into the dispatchPeers structure:
````
dispatchPeers map[Blockchain]map[string]Node	// < Blockchain structure > < GID > < Node >
````

This allows us to maintain a map of nodes delineated by the blockchain structure above for easy access. 

See tests/node/DispatchPeers_test.go for clarification

Closes #93 
Closes #94 