### PR TITLE
fixed gets in cmd dispatch message node and session modules, repaired…

### DIFF
--- a/tests/rpc/dispatch_test.go
+++ b/tests/rpc/dispatch_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/pokt-network/pocket-core/config"
-	"github.com/pokt-network/pocket-core/node"
-	"github.com/pokt-network/pocket-core/rpc/relay"
-	"github.com/pokt-network/pocket-core/rpc/shared"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/pokt-network/pocket-core/config"
+	"github.com/pokt-network/pocket-core/node"
+	"github.com/pokt-network/pocket-core/rpc/relay"
+	"github.com/pokt-network/pocket-core/rpc/shared"
 )
 
 func TestDispatchServe(t *testing.T) {
@@ -38,26 +39,18 @@ func TestDispatchServe(t *testing.T) {
 		RelayPort:   "0",
 		Blockchains: []node.Blockchain{bitcoinCash, rinkeby, bitcoinv1}}
 	// add them to dispatchPeers
-	dp := node.GetDispatchPeers()
+	dp := node.DispatchPeers()
 	dp.Add(node1)
 	dp.Add(node2)
 	dp.Add(node3)
 	// add foo to the whitelist
-	node.GetDWL().Add("foo")
+	node.DWL().Add("foo")
 	// json call string for dispatch serve
 	requestJSON := []byte("{\"DevID\": \"foo\", \"Blockchains\": [{\"name\":\"ethereum\",\"netid\":\"1\",\"version\":\"1.0\"}]}")
 	// start relay server
-<<<<<<< HEAD
-<<<<<<< HEAD
 	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.NewRouter(relay.Routes()))
->>>>>>> fixed all possible todos throughout package
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
->>>>>>> updated RPC package names, removed unnecessary 'Get' as specified in 'Effective Go'
 	// url for the POST request
-	u := "http://localhost:" + config.Get().RRPCPort + "/v1/dispatch/serve"
+	u := "http://localhost:" + config.Get().RRPCPort + "/v1/dispatch/"
 	req, err := http.NewRequest("POST", u, bytes.NewBuffer(requestJSON))
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/tests/rpc/reference_test.go
+++ b/tests/rpc/reference_test.go
@@ -1,12 +1,13 @@
 package rpc
 
 import (
-	"github.com/pokt-network/pocket-core/config"
-	"github.com/pokt-network/pocket-core/rpc/relay"
-	"github.com/pokt-network/pocket-core/rpc/shared"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/pokt-network/pocket-core/config"
+	"github.com/pokt-network/pocket-core/rpc/relay"
+	"github.com/pokt-network/pocket-core/rpc/shared"
 )
 
 /*
@@ -14,17 +15,9 @@ Unit test for APIReference
 */
 func TestApiReference(t *testing.T) {
 	// Start server instance
-<<<<<<< HEAD
-<<<<<<< HEAD
 	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.NewRouter(relay.Routes()))
->>>>>>> fixed all possible todos throughout package
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
->>>>>>> updated RPC package names, removed unnecessary 'Get' as specified in 'Effective Go'
 	// @ Url
-	u := "http://localhost:" + config.Get().RRPCPort + "/v1/dispatch/serve"
+	u := "http://localhost:" + config.Get().RRPCPort + "/v1/dispatch"
 	// Send get request
 	resp, err := http.Get(u)
 	if err != nil {

--- a/tests/rpc/relay_test.go
+++ b/tests/rpc/relay_test.go
@@ -4,38 +4,30 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
 	"github.com/pokt-network/pocket-core/config"
 	"github.com/pokt-network/pocket-core/node"
 	"github.com/pokt-network/pocket-core/rpc/relay"
 	"github.com/pokt-network/pocket-core/rpc/shared"
 	"github.com/pokt-network/pocket-core/service"
-
-	"io/ioutil"
-	"net/http"
-	"testing"
 )
 
 /*
 Unit test for the relay functionality
 */
 func TestRelay(t *testing.T) {
-	node.GetDWL().Add("DEVID1")
+	node.DWL().Add("DEVID1")
 	// grab the hosted chains via file
 	if err := node.CFIle(config.Get().CFile); err != nil {
 		t.Fatalf(err.Error())
 	}
 	node.TestChains()
-	fmt.Println(node.GetChains())
+	fmt.Println(node.Chains())
 	// Start server instance
-<<<<<<< HEAD
-<<<<<<< HEAD
 	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.NewRouter(relay.Routes()))
->>>>>>> fixed all possible todos throughout package
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
->>>>>>> updated RPC package names, removed unnecessary 'Get' as specified in 'Effective Go'
 	// @ Url
 	u := "http://localhost:" + config.Get().RRPCPort + "/v1/relay/"
 	// Setup relay

--- a/tests/rpc/report_test.go
+++ b/tests/rpc/report_test.go
@@ -4,30 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+
 	"github.com/pokt-network/pocket-core/config"
 	"github.com/pokt-network/pocket-core/const"
 	"github.com/pokt-network/pocket-core/rpc/relay"
 	"github.com/pokt-network/pocket-core/rpc/shared"
 	"github.com/pokt-network/pocket-core/service"
-
-	"io/ioutil"
-	"log"
-	"net/http"
-	"testing"
 )
 
 func TestReport(t *testing.T) {
 	report := service.Report{GID: "test", Message: "foo"}
 	// Start server instance
-<<<<<<< HEAD
-<<<<<<< HEAD
 	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.NewRouter(relay.Routes()))
->>>>>>> fixed all possible todos throughout package
-=======
-	go http.ListenAndServe(":"+config.Get().RRPCPort, shared.Router(relay.Routes()))
->>>>>>> updated RPC package names, removed unnecessary 'Get' as specified in 'Effective Go'
 	// @ Url
 	u := "http://localhost:" + config.Get().RRPCPort + "/v1/report"
 	j, err := json.Marshal(report)


### PR DESCRIPTION
… broken tests from manual merge (oops), and abstracted the GetRoutes() call to one shared.GetRoutes() call

Note: some of the 'get<>' are necessary because of duplicate names EX: GetRoutes() and Routes() are two different functions at this point.

Closes #149 