### PR TITLE
Shutdown if chains file problem

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -3,6 +3,7 @@ package node
 import (
 	"github.com/pokt-network/pocket-core/config"
 	"github.com/pokt-network/pocket-core/logs"
+	"github.com/pokt-network/pocket-core/util"
 )
 
 func Files() {
@@ -13,6 +14,7 @@ func Files() {
 	// chains.json
 	if err := CFIle(config.GlobalConfig().CFile); err != nil {
 		logs.NewLog(err.Error(), logs.WaringLevel, logs.JSONLogFormat)
+		util.ExitGracefully(err.Error() + config.GlobalConfig().CFile)
 	}
 	// whitelists for centralized dispatcher
 	WhiteListInit()


### PR DESCRIPTION
closes #158 

Added `ExitGracefully()` if problem with the chains.json

If you want to operate without hosted chains (development and dispatcher only):

1) Create chains.json in datadirectory
2) Write empty json array `[]` in the file

Should work fine!