### PR TITLE
Feature/add integration unit tests

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -24,15 +24,28 @@ set -o nounset
 # POCKET_CORE_SERVICE_IP = IP of the Pocket Core service node (required)
 # POCKET_CORE_SERVICE_PORT = Port of the Pocket Core service node (required)
 
-
-
 # Start pocket-core
 if [ $POCKET_CORE_NODE_TYPE = "dispatch" ]; then
 	echo 'Starting pocket-core dispatch'
-	exec pocket-core --dispatch --datadirectory ${POCKET_PATH_DATADIR} --dbend ${AWS_DYNAMODB_ENDPOINT:-dynamodb.us-east-1.amazonaws.com} --dbtable ${AWS_DYNAMODB_TABLE:-dispatch-peers-staging} --dbregion ${AWS_DYNAMODB_REGION:-us-east-1} --disip ${POCKET_CORE_DISPATCH_IP:-127.0.0.1} --disrport ${POCKET_CORE_DISPATCH_PORT:-8081}
+
+	exec pocket-core --dispatch \
+		--datadirectory ${POCKET_PATH_DATADIR:-datadir} \
+		--dbend ${POCKET_CORE_AWS_DYNAMODB_ENDPOINT:-dynamodb.us-east-1.amazonaws.com} \
+		--dbtable ${POCKET_CORE_AWS_DYNAMODB_TABLE:-dispatch-peers-staging} \
+		--dbregion ${POCKET_CORE_AWS_DYNAMODB_REGION:-us-east-1} \
+		--disip ${POCKET_CORE_DISPATCH_IP:-127.0.0.1} \
+		--disrport ${POCKET_CORE_DISPATCH_PORT:-8081}
+
 elif [ $POCKET_CORE_NODE_TYPE = "service" ]; then
 	echo 'Starting pocket-core service'
-	exec pocket-core --datadirectory ${POCKET_PATH_DATADIR} --disip ${POCKET_CORE_DISPATCH_IP:-127.0.0.1} --disrport ${POCKET_CORE_DISPATCH_PORT:-8081} --gid ${POCKET_CORE_SERVICE_GID} --ip ${POCKET_CORE_SERVICE_IP} --port ${POCKET_CORE_SERVICE_PORT}
+
+	exec pocket-core --datadirectory ${POCKET_PATH_DATADIR:-datadir} \
+		--disip ${POCKET_CORE_DISPATCH_IP:-127.0.0.1} \
+		--gid ${POCKET_CORE_SERVICE_GID:-GID2} \
+		--ip ${POCKET_CORE_SERVICE_IP:-127.0.0.1} \
+		--disrport ${POCKET_CORE_DISPATCH_PORT:-8081} \
+		--port ${POCKET_CORE_SERVICE_PORT:-8081}
+
 else
 	echo 'Need to specify a node type, either dispatch or service.'
 	exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,20 +23,22 @@ set -o nounset
 cmd="$@"
 
 # Download node configurations from S3
-echo 'Downloading node configurations'
-aws s3 sync $POCKET_CORE_S3_CONFIG_URL $POCKET_PATH_DATADIR
+
+if [  ${POCKET_CORE_S3_CONFIG_URL:-false} != false ]; then
+    echo 'Downloading node configurations'
+    aws s3 sync $POCKET_CORE_S3_CONFIG_URL ${POCKET_PATH_DATADIR:-datadir}
+fi
 
 # Running tests
 
-
 if [ ${POCKET_CORE_UNIT_TESTS:-false} == true ]; then
     echo "Initializing unit testing"
-    go test ./tests/unit/...
+    go test ./tests/unit/...  
 fi
 
 if [ ${POCKET_CORE_INTEGRATION_TESTS:-false}  == true ]; then
     echo "Initializing integration testing"
-    go test ./tests/integration/...
+    go test ./tests/integration/... --disip ${POCKET_CORE_DISPATCH_IP:-127.0.0.1} --disrport ${POCKET_CORE_DISPATCH_PORT:-8081}
 fi
 
 


### PR DESCRIPTION
- Add prettier code format for defining args on `cmd.sh`
- Add default values for all `POCKET_CORE` values in case no value is defined
- Add prefix `POCKET_CORE`for DYNAMODB enviroment variables
- Add required `args` for running integration tests 