### PR TITLE
query block RPC returns JSON object instead of string

### DIFF
--- a/app/cmd/rpc/query.go
+++ b/app/cmd/rpc/query.go
@@ -44,7 +44,7 @@ func Block(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		WriteErrorResponse(w, 400, err.Error())
 		return
 	}
-	WriteResponse(w, string(res), r.URL.Path, r.Host)
+	WriteJSONResponse(w, string(res), r.URL.Path, r.Host)
 }
 
 func Tx(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/app/cmd/rpc/rpc_test.go
+++ b/app/cmd/rpc/rpc_test.go
@@ -52,7 +52,7 @@ func TestRPC_QueryBlock(t *testing.T) {
 		q := newQueryRequest("block", newBody(params))
 		rec := httptest.NewRecorder()
 		Block(rec, q, httprouter.Params{})
-		resp := getResponse(rec)
+		resp := getJSONResponse(rec)
 		assert.NotNil(t, resp)
 		assert.NotEmpty(t, resp)
 		var blk core_types.ResultBlock
@@ -550,4 +550,14 @@ func getResponse(rec *httptest.ResponseRecorder) string {
 		panic("could not unquote resp: " + err.Error())
 	}
 	return resp
+}
+
+func getJSONResponse(rec *httptest.ResponseRecorder) []byte {
+	res := rec.Result()
+	defer res.Body.Close()
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		panic("could not read response: " + err.Error())
+	}
+	return b
 }

--- a/app/cmd/rpc/server.go
+++ b/app/cmd/rpc/server.go
@@ -83,6 +83,15 @@ func WriteResponse(w http.ResponseWriter, jsn, path, ip string) {
 		}
 	}
 }
+func WriteJSONResponse(w http.ResponseWriter, jsn, path, ip string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(jsn), &raw); err != nil {
+		WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Println(err.Error())
+	}
+	json.NewEncoder(w).Encode(raw)}
 
 func WriteErrorResponse(w http.ResponseWriter, errorCode int, errorMsg string) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")


### PR DESCRIPTION
fixes #561 