### PR TITLE
Add pagination 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,6 @@ indent_style = tab
 
 [*.yml]
 indent_style = space
+
+[*.yaml]
+indent_style = space

--- a/app/cmd/cli/query.go
+++ b/app/cmd/cli/query.go
@@ -214,15 +214,20 @@ var queryAccount = &cobra.Command{
 }
 
 var nodeStakingStatus string
+var page int
+var limit int
 
 func init() {
 	queryNodes.Flags().StringVar(&nodeStakingStatus, "staking-status", "", "the staking status of the node")
+	queryNodes.Flags().IntVar(&page, "page", 1, "mark the page you want")
+	queryNodes.Flags().IntVar(&limit, "limit", 10000, "reduce the amount of results")
 }
 
 var queryNodes = &cobra.Command{
-	Use:   "nodes --staking-status=<nodeStakingStatus> <height>",
+	Use:   "nodes --staking-status=<nodeStakingStatus> --page=<page> --limit=<limit> <height>",
 	Short: "Gets nodes",
 	Long:  `Retrieves the list of all nodes known at the specified <height>.`,
+	// Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		app.SetTMNode(tmNode)
 		var height int
@@ -235,32 +240,36 @@ var queryNodes = &cobra.Command{
 				fmt.Println(err)
 				return
 			}
+			// page, err = strconv.Atoi(args[1])
+			// if err != nil {
+			// 	page = 1
+			// }
+			// limit, err = strconv.Atoi(args[2])
+			// if err != nil {
+			// 	limit = 10000
+			// }
 		}
-		var res nodeTypes.Validators
+		var res nodeTypes.ValidatorsPage
 		var err error
 		switch strings.ToLower(nodeStakingStatus) {
 		case "":
 			// no status passed
-			res, err = app.QueryAllNodes(int64(height))
+			res, err = app.QueryAllNodes(int64(height), page, limit)
 		case "staked":
 			// staked nodes
-			res, err = app.QueryStakedNodes(int64(height))
+			res, err = app.QueryStakedNodes(int64(height), page, limit)
 		case "unstaked":
 			// unstaked nodes
-			res, err = app.QueryUnstakedNodes(int64(height))
+			res, err = app.QueryUnstakedNodes(int64(height), page, limit)
 		case "unstaking":
 			// unstaking nodes
-			res, err = app.QueryUnstakingNodes(int64(height))
+			res, err = app.QueryUnstakingNodes(int64(height), page, limit)
 		default:
 			fmt.Println("invalid staking status, can be staked, unstaked, unstaking, or empty")
 			return
 		}
 		if err != nil {
 			fmt.Println(err)
-			return
-		}
-		if res == nil {
-			fmt.Println("nil nodes result")
 			return
 		}
 		fmt.Printf("Nodes\n%s\n", res.String())

--- a/app/cmd/cli/query.go
+++ b/app/cmd/cli/query.go
@@ -240,14 +240,6 @@ var queryNodes = &cobra.Command{
 				fmt.Println(err)
 				return
 			}
-			// page, err = strconv.Atoi(args[1])
-			// if err != nil {
-			// 	page = 1
-			// }
-			// limit, err = strconv.Atoi(args[2])
-			// if err != nil {
-			// 	limit = 10000
-			// }
 		}
 		var res nodeTypes.ValidatorsPage
 		var err error
@@ -336,7 +328,7 @@ func init() {
 }
 
 var queryApps = &cobra.Command{
-	Use:   "apps --staking-status=<nodeStakingStatus> <height>",
+	Use:   "apps --staking-status=<nodeStakingStatus> --page=<page> --limit=<limit> <height>",
 	Short: "Gets apps",
 	Long:  `Retrieves the list of all applications known at the specified <height>`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -352,31 +344,27 @@ var queryApps = &cobra.Command{
 				return
 			}
 		}
-		var res appTypes.Applications
+		var res appTypes.ApplicationsPage
 		var err error
 		switch strings.ToLower(appStakingStatus) {
 		case "":
 			// no status passed
-			res, err = app.QueryAllApps(int64(height))
+			res, err = app.QueryAllApps(int64(height), page, limit)
 		case "staked":
 			// staked nodes
-			res, err = app.QueryStakedApps(int64(height))
+			res, err = app.QueryStakedApps(int64(height), page, limit)
 		case "unstaked":
 			// unstaked nodes
-			res, err = app.QueryUnstakedApps(int64(height))
+			res, err = app.QueryUnstakedApps(int64(height), page, limit)
 		case "unstaking":
 			// unstaking nodes
-			res, err = app.QueryUnstakingApps(int64(height))
+			res, err = app.QueryUnstakingApps(int64(height), page, limit)
 		default:
 			fmt.Printf("invalid staking status, can be staked, unstaked, unstaking, or empty")
 			return
 		}
 		if err != nil {
 			fmt.Println(err)
-			return
-		}
-		if res == nil {
-			fmt.Println("nil Apps result")
 			return
 		}
 		fmt.Printf("Apps:\n%s\n", res.String())

--- a/app/cmd/rpc/query.go
+++ b/app/cmd/rpc/query.go
@@ -307,21 +307,21 @@ func Apps(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		WriteErrorResponse(w, 400, err.Error())
 		return
 	}
-	var res appTypes.Applications
+	var res appTypes.ApplicationsPage
 	var err error
 	switch strings.ToLower(params.StakingStatus) {
 	case "":
 		// no status passed
-		res, err = app.QueryAllApps(params.Height)
+		res, err = app.QueryAllApps(params.Height, params.Page, params.PerPage)
 	case "staked":
 		// staked nodes
-		res, err = app.QueryStakedApps(params.Height)
+		res, err = app.QueryStakedApps(params.Height, params.Page, params.PerPage)
 	case "unstaked":
 		// unstaked nodes
-		res, err = app.QueryUnstakedApps(params.Height)
+		res, err = app.QueryUnstakedApps(params.Height, params.Page, params.PerPage)
 	case "unstaking":
 		// unstaking nodes
-		res, err = app.QueryUnstakingApps(params.Height)
+		res, err = app.QueryUnstakingApps(params.Height, params.Page, params.PerPage)
 	default:
 		panic("invalid staking status, can be staked, unstaked, unstaking, or empty")
 	}

--- a/app/cmd/rpc/query.go
+++ b/app/cmd/rpc/query.go
@@ -32,6 +32,8 @@ type heightAddrParams struct {
 type heightAndStakingStatusParams struct {
 	Height        int64  `json:"height"`
 	StakingStatus string `json:"staking_status"`
+	Page          int    `json:"page,omitempty"`
+	PerPage       int    `json:"per_page,omitempty"`
 }
 
 type paginatedAddressParams struct {
@@ -181,21 +183,21 @@ func Nodes(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		WriteErrorResponse(w, 400, err.Error())
 		return
 	}
-	var res nodeTypes.Validators
+	var res nodeTypes.ValidatorsPage
 	var err error
 	switch strings.ToLower(params.StakingStatus) {
 	case "":
 		// no status passed
-		res, err = app.QueryAllNodes(params.Height)
+		res, err = app.QueryAllNodes(params.Height, params.Page, params.PerPage)
 	case "staked":
 		// staked nodes
-		res, err = app.QueryStakedNodes(params.Height)
+		res, err = app.QueryStakedNodes(params.Height, params.Page, params.PerPage)
 	case "unstaked":
 		// unstaked nodes
-		res, err = app.QueryUnstakedNodes(params.Height)
+		res, err = app.QueryUnstakedNodes(params.Height, params.Page, params.PerPage)
 	case "unstaking":
 		// unstaking nodes
-		res, err = app.QueryUnstakingNodes(params.Height)
+		res, err = app.QueryUnstakingNodes(params.Height, params.Page, params.PerPage)
 	default:
 		panic("invalid staking status, can be staked, unstaked, unstaking, or empty")
 	}

--- a/app/cmd/rpc/rpc_test.go
+++ b/app/cmd/rpc/rpc_test.go
@@ -333,11 +333,15 @@ func TestRPC_QueryApps(t *testing.T) {
 		var params = heightAndStakingStatusParams{
 			Height:        0,
 			StakingStatus: "staked",
+			Page:          1,
+			PerPage:       10000,
 		}
 		q := newQueryRequest("apps", newBody(params))
 		rec := httptest.NewRecorder()
 		Apps(rec, q, httprouter.Params{})
-		assert.True(t, strings.Contains(rec.Body.String(), app.GetAddress().String()))
+		body := rec.Body.String()
+		address := app.GetAddress().String()
+		assert.True(t, strings.Contains(body, address))
 	}
 	cleanup()
 	stopCli()

--- a/app/common_test.go
+++ b/app/common_test.go
@@ -3,6 +3,11 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
 	apps "github.com/pokt-network/pocket-core/x/apps"
 	appsKeeper "github.com/pokt-network/pocket-core/x/apps/keeper"
 	appsTypes "github.com/pokt-network/pocket-core/x/apps/types"
@@ -37,10 +42,6 @@ import (
 	cTypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
-	"io"
-	"os"
-	"testing"
-	"time"
 )
 
 func NewInMemoryTendermintNode(t *testing.T, genesisState []byte) (tendermintNode *node.Node, keybase keys.Keybase, cleanup func()) {
@@ -264,6 +265,7 @@ func getRandomPrivateKey() crypto.Ed25519PrivateKey {
 }
 
 func inMemTendermintNode(genesisState []byte) (*node.Node, keys.Keybase) {
+	// TODO add a second validator
 	kb := getInMemoryKeybase()
 	cb, err := kb.GetCoinbase()
 	if err != nil {

--- a/app/common_test.go
+++ b/app/common_test.go
@@ -473,6 +473,24 @@ func oneValTwoNodeGenesisState() []byte {
 			StakedTokens: sdk.NewInt(1000000000000000)})
 	res := memCodec().MustMarshalJSON(posGenesisState)
 	defaultGenesis[nodesTypes.ModuleName] = res
+
+	// setup application
+	rawApps := defaultGenesis[appsTypes.ModuleName]
+	var appsGenesisState appsTypes.GenesisState
+	memCodec().MustUnmarshalJSON(rawApps, &appsGenesisState)
+	// app 1
+	appsGenesisState.Applications = append(appsGenesisState.Applications, appsTypes.Application{
+		Address:                 kp2.GetAddress(),
+		PublicKey:               kp2.PublicKey,
+		Jailed:                  false,
+		Status:                  sdk.Staked,
+		Chains:                  []string{dummyChainsHash},
+		StakedTokens:            sdk.NewInt(10000000),
+		MaxRelays:               sdk.NewInt(100000),
+		UnstakingCompletionTime: time.Time{},
+	})
+	res2 := memCodec().MustMarshalJSON(appsGenesisState)
+	defaultGenesis[appsTypes.ModuleName] = res2
 	// set coinbase as account holding coins
 	rawAccounts := defaultGenesis[auth.ModuleName]
 	var authGenState auth.GenesisState
@@ -488,15 +506,15 @@ func oneValTwoNodeGenesisState() []byte {
 		Coins:   sdk.NewCoins(sdk.NewCoin(sdk.DefaultStakeDenom, sdk.NewInt(1000000000))),
 		PubKey:  pubKey,
 	})
-	res2 := memCodec().MustMarshalJSON(authGenState)
-	defaultGenesis[auth.ModuleName] = res2
+	res3 := memCodec().MustMarshalJSON(authGenState)
+	defaultGenesis[auth.ModuleName] = res3
 	// set default chain for module
 	rawPocket := defaultGenesis[pocketTypes.ModuleName]
 	var pocketGenesisState pocketTypes.GenesisState
 	memCodec().MustUnmarshalJSON(rawPocket, &pocketGenesisState)
 	pocketGenesisState.Params.SupportedBlockchains = []string{dummyChainsHash}
-	res3 := memCodec().MustMarshalJSON(pocketGenesisState)
-	defaultGenesis[pocketTypes.ModuleName] = res3
+	res4 := memCodec().MustMarshalJSON(pocketGenesisState)
+	defaultGenesis[pocketTypes.ModuleName] = res4
 	// set default governance in genesis
 	var govGenesisState govTypes.GenesisState
 	rawGov := defaultGenesis[govTypes.ModuleName]
@@ -506,8 +524,8 @@ func oneValTwoNodeGenesisState() []byte {
 	govGenesisState.Params.ACL = nMACL
 	govGenesisState.Params.DAOOwner = kp1.GetAddress()
 	govGenesisState.DAOTokens = sdk.NewInt(1000)
-	res4 := memCodec().MustMarshalJSON(govGenesisState)
-	defaultGenesis[govTypes.ModuleName] = res4
+	res5 := memCodec().MustMarshalJSON(govGenesisState)
+	defaultGenesis[govTypes.ModuleName] = res5
 	// end genesis setup
 	genState = defaultGenesis
 	j, _ := memCodec().MarshalJSONIndent(defaultGenesis, "", "    ")

--- a/app/query.go
+++ b/app/query.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+
 	apps "github.com/pokt-network/pocket-core/x/apps"
 	appsTypes "github.com/pokt-network/pocket-core/x/apps/types"
 	"github.com/pokt-network/pocket-core/x/nodes"
@@ -56,8 +57,8 @@ func QueryAccount(addr string, height int64) (account *auth.BaseAccount, err err
 	return nodes.QueryAccount(Codec(), getTMClient(), a, height)
 }
 
-func QueryAllNodes(height int64) (nodesTypes.Validators, error) {
-	return nodes.QueryValidators(Codec(), getTMClient(), height)
+func QueryAllNodes(height int64, page, limit int) (nodesTypes.ValidatorsPage, error) {
+	return nodes.QueryValidators(Codec(), getTMClient(), height, page, limit)
 }
 
 func QueryNode(addr string, height int64) (validator nodesTypes.Validator, err error) {
@@ -68,16 +69,16 @@ func QueryNode(addr string, height int64) (validator nodesTypes.Validator, err e
 	return nodes.QueryValidator(Codec(), getTMClient(), a, height)
 }
 
-func QueryUnstakingNodes(height int64) (validators nodesTypes.Validators, err error) {
-	return nodes.QueryUnstakingValidators(Codec(), getTMClient(), height)
+func QueryUnstakingNodes(height int64, page, limit int) (nodesTypes.ValidatorsPage, error) {
+	return nodes.QueryUnstakingValidators(Codec(), getTMClient(), height, page, limit)
 }
 
-func QueryStakedNodes(height int64) (validators nodesTypes.Validators, err error) {
-	return nodes.QueryStakedValidators(Codec(), getTMClient(), height)
+func QueryStakedNodes(height int64, page, limit int) (nodesTypes.ValidatorsPage, error) {
+	return nodes.QueryStakedValidators(Codec(), getTMClient(), height, page, limit)
 }
 
-func QueryUnstakedNodes(height int64) (validators nodesTypes.Validators, err error) {
-	return nodes.QueryUnstakedValidators(Codec(), getTMClient(), height)
+func QueryUnstakedNodes(height int64, page, limit int) (nodesTypes.ValidatorsPage, error) {
+	return nodes.QueryUnstakedValidators(Codec(), getTMClient(), height, page, limit)
 }
 
 func QueryNodeParams(height int64) (params nodesTypes.Params, err error) {

--- a/app/query.go
+++ b/app/query.go
@@ -113,8 +113,8 @@ func QueryACL(height int64) (acl types.ACL, err error) {
 	return gov.QueryACL(Codec(), getTMClient(), height)
 }
 
-func QueryAllApps(height int64) (appsTypes.Applications, error) {
-	return apps.QueryApplications(Codec(), getTMClient(), height)
+func QueryAllApps(height int64, page, limit int) (appsTypes.ApplicationsPage, error) {
+	return apps.QueryApplications(Codec(), getTMClient(), height, page, limit)
 }
 
 func QueryApp(addr string, height int64) (validator appsTypes.Application, err error) {
@@ -125,16 +125,16 @@ func QueryApp(addr string, height int64) (validator appsTypes.Application, err e
 	return apps.QueryApplication(Codec(), getTMClient(), a, height)
 }
 
-func QueryUnstakingApps(height int64) (validators appsTypes.Applications, err error) {
-	return apps.QueryUnstakingApplications(Codec(), getTMClient(), height)
+func QueryUnstakingApps(height int64, page, limit int) (appsTypes.ApplicationsPage, error) {
+	return apps.QueryUnstakingApplications(Codec(), getTMClient(), height, page, limit)
 }
 
-func QueryStakedApps(height int64) (validators appsTypes.Applications, err error) {
-	return apps.QueryStakedApplications(Codec(), getTMClient(), height)
+func QueryStakedApps(height int64, page, limit int) (appsTypes.ApplicationsPage, error) {
+	return apps.QueryStakedApplications(Codec(), getTMClient(), height, page, limit)
 }
 
-func QueryUnstakedApps(height int64) (validators appsTypes.Applications, err error) {
-	return apps.QueryUnstakedApplications(Codec(), getTMClient(), height)
+func QueryUnstakedApps(height int64, page, limit int) (appsTypes.ApplicationsPage, error) {
+	return apps.QueryUnstakedApplications(Codec(), getTMClient(), height, page, limit)
 }
 
 func QueryTotalAppCoins(height int64) (staked sdk.Int, unstaked sdk.Int, err error) {

--- a/app/query_test.go
+++ b/app/query_test.go
@@ -92,9 +92,9 @@ func TestQueryValidators(t *testing.T) {
 	memCli, stopCli, evtChan := subscribeTo(t, tmTypes.EventNewBlock)
 	select {
 	case <-evtChan:
-		got, err := nodes.QueryValidators(memCodec(), memCli, 1)
+		got, err := nodes.QueryValidators(memCodec(), memCli, 1, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(got))
+		assert.Equal(t, 1, len(got.Result))
 	}
 	cleanup()
 	stopCli()
@@ -217,9 +217,9 @@ func TestQueryStakedValidator(t *testing.T) {
 	memCli, stopCli, evtChan := subscribeTo(t, tmTypes.EventNewBlock)
 	select {
 	case <-evtChan:
-		got, err := nodes.QueryStakedValidators(memCodec(), memCli, 0)
+		got, err := nodes.QueryStakedValidators(memCodec(), memCli, 0, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(got))
+		assert.Equal(t, 1, len(got.Result))
 	}
 	cleanup()
 	stopCli()

--- a/app/query_test.go
+++ b/app/query_test.go
@@ -88,13 +88,19 @@ func TestQueryNodeStatus(t *testing.T) {
 }
 
 func TestQueryValidators(t *testing.T) {
-	_, _, cleanup := NewInMemoryTendermintNode(t, oneValTwoNodeGenesisState())
+	_, _, cleanup := NewInMemoryTendermintNode(t, twoValTwoNodeGenesisState())
 	memCli, stopCli, evtChan := subscribeTo(t, tmTypes.EventNewBlock)
 	select {
 	case <-evtChan:
 		got, err := nodes.QueryValidators(memCodec(), memCli, 1, 1, 1)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(got.Result))
+		got, err = nodes.QueryValidators(memCodec(), memCli, 1, 2, 1)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(got.Result))
+		got, err = nodes.QueryValidators(memCodec(), memCli, 1, 1, 1000)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(got.Result))
 	}
 	cleanup()
 	stopCli()
@@ -350,7 +356,7 @@ func TestQueryProof(t *testing.T) {
 	stopCli()
 }
 
-func TestQueryStakedApp(t *testing.T) {
+func TestQueryStakedpp(t *testing.T) {
 	_, kb, cleanup := NewInMemoryTendermintNode(t, oneValTwoNodeGenesisState())
 	kp, err := kb.GetCoinbase()
 	assert.Nil(t, err)

--- a/app/tx_test.go
+++ b/app/tx_test.go
@@ -51,7 +51,7 @@ func TestUnstakeApp(t *testing.T) {
 		assert.Equal(t, 1, len(got.Result))
 		got, err = apps.QueryStakedApplications(memCodec(), memCli, 0, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(got.Result))
+		assert.Equal(t, 1, len(got.Result)) // default genesis application
 	}
 	cleanup()
 	stopCli()
@@ -152,9 +152,9 @@ func TestStakeApp(t *testing.T) {
 	}
 	select {
 	case <-evtChan:
-		got, err := apps.QueryApplications(memCodec(), memCli, 0, 1, 1)
+		got, err := apps.QueryApplications(memCodec(), memCli, 0, 1, 2)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(got.Result))
+		assert.Equal(t, 2, len(got.Result))
 	}
 	stopCli()
 	cleanup()

--- a/app/tx_test.go
+++ b/app/tx_test.go
@@ -38,20 +38,20 @@ func TestUnstakeApp(t *testing.T) {
 	}
 	select {
 	case <-evtChan:
-		got, err := apps.QueryApplications(memCodec(), memCli, 0)
+		got, err := apps.QueryApplications(memCodec(), memCli, 0, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(got))
+		assert.Equal(t, 1, len(got.Result))
 		memCli, stopCli, evtChan = subscribeTo(t, tmTypes.EventTx)
 		tx, err = apps.UnstakeTx(memCodec(), memCli, kb, kp.GetAddress(), "test")
 	}
 	select {
 	case <-evtChan:
-		got, err := apps.QueryUnstakingApplications(memCodec(), memCli, 0)
+		got, err := apps.QueryUnstakingApplications(memCodec(), memCli, 0, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(got))
-		got, err = apps.QueryStakedApplications(memCodec(), memCli, 0)
+		assert.Equal(t, 1, len(got.Result))
+		got, err = apps.QueryStakedApplications(memCodec(), memCli, 0, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(got))
+		assert.Equal(t, 0, len(got.Result))
 	}
 	cleanup()
 	stopCli()
@@ -80,21 +80,21 @@ func TestUnstakeNode(t *testing.T) {
 			select {
 			case res := <-evtChan:
 				if len(res.Events["begin_unstake.module"]) == 1 {
-					got, err := nodes.QueryUnstakingValidators(memCodec(), memCli, 0)
+					got, err := nodes.QueryUnstakingValidators(memCodec(), memCli, 0, 1, 1)
 					assert.Nil(t, err)
-					assert.Equal(t, 1, len(got))
-					got, err = nodes.QueryStakedValidators(memCodec(), memCli, 0)
+					assert.Equal(t, 1, len(got.Result))
+					got, err = nodes.QueryStakedValidators(memCodec(), memCli, 0, 1, 1)
 					assert.Nil(t, err)
-					assert.Equal(t, 1, len(got))
+					assert.Equal(t, 1, len(got.Result))
 					memCli, stopCli, evtChan = subscribeTo(t, tmTypes.EventNewBlockHeader)
 					select {
 					case res := <-evtChan:
 						if len(res.Events["unstake.module"]) == 1 {
-							got, err := nodes.QueryUnstakedValidators(memCodec(), memCli, 0)
+							got, err := nodes.QueryUnstakedValidators(memCodec(), memCli, 0, 1, 1)
 							assert.Nil(t, err)
-							assert.Equal(t, 1, len(got))
-							assert.Equal(t, got[0].StakedTokens.Int64(), int64(0))
-							addr := got[0].Address
+							assert.Equal(t, 1, len(got.Result))
+							assert.Equal(t, got.Result[0].StakedTokens.Int64(), int64(0))
+							addr := got.Result[0].Address
 							balance, err := nodes.QueryAccountBalance(memCodec(), memCli, addr, 0)
 							assert.NotZero(t, balance.Int64())
 							tx, err = nodes.StakeTx(memCodec(), memCli, kb, chains, "https://myPocketNode:8080", sdk.NewInt(10000000), kp, "test")
@@ -152,9 +152,9 @@ func TestStakeApp(t *testing.T) {
 	}
 	select {
 	case <-evtChan:
-		got, err := apps.QueryApplications(memCodec(), memCli, 0)
+		got, err := apps.QueryApplications(memCodec(), memCli, 0, 1, 1)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(got))
+		assert.Equal(t, 1, len(got.Result))
 	}
 	stopCli()
 	cleanup()

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -25,6 +25,8 @@
   - transitive change in Account JSON response for RPC
   - Updated rpc-spec to reflect change
 - Updated POSMint to address duplicated minting logs
+- Add pagination to Application Queries for RPC & CLI
+- Add pagination to Nodes Queries for RPC & CLI
 
 ## RC-0.2.1
 - Add version command to CLI

--- a/doc/cli-interface-spec.md
+++ b/doc/cli-interface-spec.md
@@ -1,5 +1,5 @@
 # Pocket Core CLI Interface Specification
-## Version 0.0.1
+## Version RC-0.3.0
 
 ### Overview
 This document serves as a specification for the Command Line Interface of the Pocket Core application. There's no protocol verification for these commands because they map closely to protocol functions.
@@ -284,11 +284,13 @@ Block Height: <current block height>
 Account balance: <balance of the account>
 ```
 
-- `pocket query all-nodes --staking-status=<stakingStatus> <height>`
-> Returns the list of all nodes known at the specified `<height>`.
+- `pocket query nodes --staking-status=<stakingStatus> --page=<page> --limit=<limit> <height>`
+> Returns a page containing a list of nodes known at the specified `<height>`.
 >
 > Options:
 > - `--staking-status`: Filters the node list with a staking status. Supported statuses are: `STAKED`, `UNSTAKED` and `UNSTAKING`.
+> - `--page`: The current page you want to query.
+> - `--limit`: The maximum amount of nodes per page.
 >
 > Arguments:
 > - `<height>`: The specified height of the block to be queried. Defaults to `0` which brings the latest block known to this node.
@@ -319,11 +321,13 @@ Account balance: <balance of the account>
 > Arguments:
 > - `<height>`: The specified height of the block to be queried. Defaults to `0` which brings the latest block known to this node.
 
-- `pocket query all-apps --staking-status=<stakingStatus> <height>`
-> Returns the list of all applications known at the specified `<height>`.
+- `pocket query apps --staking-status=<stakingStatus> --page=<page> --limit=<limit> <height>`
+> Returns a page containing a  list of applications known at the specified `<height>`.
 >
 > Options:
 > - `--staking-status`: Filters the node list with a staking status. Supported statuses are: `STAKED`, `UNSTAKED` and `UNSTAKING`.
+> - `--page`: The current page you want to query.
+> - `--limit`: The maximum amount of nodes per page.
 >
 > Arguments:
 > - `<height>`: The specified height of the block to be queried. Defaults to `0` which brings the latest block known to this node.
@@ -369,4 +373,3 @@ Account balance: <balance of the account>
 >
 > Arguments:
 > - `<height>`: The specified height of the block to be queried. Defaults to `0` which brings the latest block known to this node.
-

--- a/doc/rpc-spec.json
+++ b/doc/rpc-spec.json
@@ -435,7 +435,7 @@
 		  "query"
 		],
 		"requestBody": {
-		  "description": "Request the list of all applications known at the specified height and staking status, empty (\"\") staking_status returns all apps",
+		  "description": "Request a page of applications known at the specified height and staking status, empty (\"\") staking_status returns all apps",
 		  "content": {
 			"application/json": {
 			  "schema": {
@@ -443,7 +443,9 @@
 			  },
 			  "example": {
 				"staking_status": "staked",
-				"height": 2
+				"height": 2,
+				"page": 1,
+				"limit": 100
 			  }
 			}
 		  },
@@ -451,11 +453,11 @@
 		},
 		"responses": {
 		  "200": {
-			"description": "Returns the list of all applications known at the specified height and staking status",
+			"description": "Returns a page of applications known at the specified height and staking status, within the limit per page",
 			"content": {
 			  "application/json": {
 				"schema": {
-				  "$ref": "#/components/schemas/Applications"
+				  "$ref": "#/components/schemas/QueryAppsResponse"
 				}
 			  }
 			}
@@ -820,7 +822,7 @@
 		  "query"
 		],
 		"requestBody": {
-		  "description": "Request the list of all nodes known at the specified height and staking status , empty (\"\") staking_status returns all nodes",
+		  "description": "Request a page nodes known at the specified height and staking status , empty (\"\") staking_status returns all nodes",
 		  "content": {
 			"application/json": {
 			  "schema": {
@@ -828,7 +830,9 @@
 			  },
 			  "example": {
 				"staking_status": "staked",
-				"height": 2
+				"height": 2,
+				"page": 1,
+				"limit": 100
 			  }
 			}
 		  },
@@ -836,28 +840,32 @@
 		},
 		"responses": {
 		  "200": {
-			"description": "Returns the list of all nodes known at the specified height and staking status",
+			"description": "Returns a page of nodes known at the specified height and staking status, within the limit per page",
 			"content": {
 			  "application/json": {
 				"schema": {
 				  "$ref": "#/components/schemas/QueryNodesResponse"
 				},
-				"example": [
-				  {
-					"address": "98a18a38aa6826a55dccce19f607e3171cf1436e",
-					"public_key": "d6b3785f00961059d2a5c6448cae7ddb02475de79c22261687a92cb905ff0de9",
-					"jailed": false,
-					"status": 2,
-					"tokens": "1000000000000000",
-					"service_url": "0.0.0.0:8081",
-					"chains": [
-					  "36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80"
+				"example": {
+					"result": [
+				  	{
+							"address": "98a18a38aa6826a55dccce19f607e3171cf1436e",
+							"public_key": "d6b3785f00961059d2a5c6448cae7ddb02475de79c22261687a92cb905ff0de9",
+							"jailed": false,
+							"status": 2,
+							"tokens": "1000000000000000",
+							"service_url": "0.0.0.0:8081",
+							"chains": [
+							  "36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80"
+							],
+							"unstaking_time": "0001-01-01T00:00:00Z"
+						}
 					],
-					"unstaking_time": "0001-01-01T00:00:00Z"
-				  }
-				]
-			  }
+			  "page": 1,
+			   "total_pages": 10
+			 }
 			}
+		}
 		  },
 		  "400": {
 			"description": "Failed to retrieve the nodes' information"
@@ -1839,9 +1847,45 @@
 		}
 	  },
 	  "QueryNodesResponse": {
-		"type": "array",
-		"items": {
-		  "$ref": "#/components/schemas/Node"
+		"type": "object",
+		"properties": {
+			"result": {
+				"type": "array",
+				"items": {
+		  		"$ref": "#/components/schemas/Node"
+				},
+			"page": {
+				"type": "integer",
+				"format": "int64",
+				"description": "current page"
+			},
+			"total_pages": {
+				"type": "integer",
+				"format": "int64",
+				"description": "maximum amount of available pages"
+			}
+			}
+		}
+	  },
+	  "QueryAppsResponse": {
+		"type": "object",
+		"properties": {
+			"result": {
+				"type": "array",
+				"items": {
+		  		"$ref": "#/components/schemas/Application"
+				},
+			"page": {
+				"type": "integer",
+				"format": "int64",
+				"description": "current page"
+			},
+			"total_pages": {
+				"type": "integer",
+				"format": "int64",
+				"description": "maximum amount of available pages"
+			}
+			}
 		}
 	  },
 	  "QueryRawTXRequest": {
@@ -1970,6 +2014,14 @@
 		"type": "object",
 		"properties": {
 		  "height": {
+			"type": "integer",
+			"format": "int64"
+		  },
+		  "page": {
+			"type": "integer",
+			"format": "int64"
+		  },
+		  "per_page": {
 			"type": "integer",
 			"format": "int64"
 		  },

--- a/doc/rpc-spec.md
+++ b/doc/rpc-spec.md
@@ -77,7 +77,7 @@ The `query` namespace handles all queries to the current world state built on th
     request: `heightAddrParams`
 
 - /v1/query/nodes
-> Query Nodes in the pocket network by height and staking_status, empty ("") staking_status returns all nodes
+> Query Nodes in the pocket network by height and staking_status, empty ("") staking_status returns a page of nodes
 
     request: `heightAndStakingStatusParams`
 
@@ -104,7 +104,7 @@ The `query` namespace handles all queries to the current world state built on th
     response: `pocketTypes.Receipt`
 
 - /v1/query/apps
-> Query Apps in the pocket network by height and staking_status, empty ("") staking_status returns all apps
+> Query Apps in the pocket network by height and staking_status, empty ("") staking_status returns a page of apps
 
     request: `heightAndStakingStatusParams`
 
@@ -134,4 +134,3 @@ The `query` namespace handles all queries to the current world state built on th
     request `heightParams`
 
     response: `querySupplyResponse`
-

--- a/doc/rpc-spec.yaml
+++ b/doc/rpc-spec.yaml
@@ -282,7 +282,7 @@ paths:
       tags:
         - query
       requestBody:
-        description: 'Request the list of all applications known at the specified height and staking status, empty ("") staking_status returns all apps'
+        description: 'Request a page of applications known at the specified height and staking status, empty ("") staking_status returns all apps, page < 1 returns the first page, per_page < 1 returns 10000 elements per page'
         content:
           application/json:
             schema:
@@ -290,6 +290,8 @@ paths:
             example:
               staking_status: staked
               height: 2
+              page: 1
+              per_page: 100
         required: true
       responses:
         '200':
@@ -297,7 +299,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Applications'
+                $ref: '#/components/schemas/QueryAppsResponse'
         '400':
           description: Failed to retrieve the applications
   /query/balance:
@@ -536,7 +538,7 @@ paths:
       tags:
         - query
       requestBody:
-        description: 'Request the list of all nodes known at the specified height and staking status , empty ("") staking_status returns all nodes'
+        description: 'Request a page of nodes known at the specified height and staking status , empty ("") staking_status returns all nodes, page < 1 returns the first page, per_page < 1 returns 10000 elements per page'
         content:
           application/json:
             schema:
@@ -544,6 +546,8 @@ paths:
             example:
               staking_status: staked
               height: 2
+              page: 1
+              per_page: 100
         required: true
       responses:
         '200':
@@ -553,15 +557,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/QueryNodesResponse'
               example:
-                - address: 98a18a38aa6826a55dccce19f607e3171cf1436e
-                  public_key: d6b3785f00961059d2a5c6448cae7ddb02475de79c22261687a92cb905ff0de9
-                  jailed: false
-                  status: 2
-                  tokens: '1000000000000000'
-                  service_url: '0.0.0.0:8081'
-                  chains:
-                    - 36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80
-                  unstaking_time: '0001-01-01T00:00:00Z'
+                result:
+                  - address: 98a18a38aa6826a55dccce19f607e3171cf1436e
+                    public_key: d6b3785f00961059d2a5c6448cae7ddb02475de79c22261687a92cb905ff0de9
+                    jailed: false
+                    status: 2
+                    tokens: '1000000000000000'
+                    service_url: '0.0.0.0:8081'
+                    chains:
+                      - 36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80
+                    unstaking_time: '0001-01-01T00:00:00Z'
+                page: 1
+                total_pages: 100
         '400':
           description: Failed to retrieve the nodes' information
   /query/pocketparams:
@@ -1277,9 +1284,35 @@ components:
           items:
             $ref: '#/components/schemas/StoredReceipt'
     QueryNodesResponse:
-      type: array
-      items:
-        $ref: '#/components/schemas/Node'
+      type: object
+      properties:
+        result:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+        page:
+          type: integer
+          format: int64
+          description: current page
+        total_pages:
+          type: integer
+          format: int64
+          description: maximum amount of pages
+    QueryAppsResponse:
+      type: object
+      properties:
+        result:
+          type: array
+          items:
+            $ref: '#/components/schemas/Application'
+        page:
+          type: integer
+          format: int64
+          description: current page
+        total_pages:
+          type: integer
+          format: int64
+          description: maximum amount of pages
     QueryRawTXRequest:
       type: object
       properties:
@@ -1369,6 +1402,12 @@ components:
       type: object
       properties:
         height:
+          type: integer
+          format: int64
+        page:
+          type: integer
+          format: int64
+        per_page:
           type: integer
           format: int64
         staking_status:

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stumble/gorocksdb v0.0.3 h1:9UU+QA1pqFYJuf9+5p7z1IqdE5k0mma4UAeu2wmX8kA=
 github.com/stumble/gorocksdb v0.0.3/go.mod h1:v6IHdFBXk5DJ1K4FZ0xi+eY737quiiBxYtSWXadLybY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/x/apps/keeper/querier_test.go
+++ b/x/apps/keeper/querier_test.go
@@ -1,12 +1,13 @@
 package keeper
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/pokt-network/pocket-core/x/apps/types"
 	sdk "github.com/pokt-network/posmint/types"
 	"github.com/tendermint/go-amino"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"reflect"
-	"testing"
 )
 
 func Test_queryApplications(t *testing.T) {
@@ -20,7 +21,9 @@ func Test_queryApplications(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Application{}, "", "  ")
+
+	expectedApplicationsPage := types.ApplicationsPage{Result: []types.Application{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedApplicationsPage, "", "  ")
 	tests := []struct {
 		name  string
 		args  args
@@ -125,7 +128,8 @@ func Test_queryStakedApplications(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Application{}, "", "  ")
+	expectedApplicationsPage := types.ApplicationsPage{Result: []types.Application{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedApplicationsPage, "", "  ")
 	tests := []struct {
 		name  string
 		args  args
@@ -227,7 +231,8 @@ func Test_queryUnstakingApplications(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Application{}, "", "  ")
+	expectedApplicationsPage := types.ApplicationsPage{Result: []types.Application{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedApplicationsPage, "", "  ")
 	tests := []struct {
 		name  string
 		args  args
@@ -264,7 +269,8 @@ func Test_queryUnstakedApplications(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Application{}, "", "  ")
+	expectedApplicationsPage := types.ApplicationsPage{Result: []types.Application{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedApplicationsPage, "", "  ")
 	tests := []struct {
 		name  string
 		args  args
@@ -305,7 +311,8 @@ func Test_NewQuerier(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Application{}, "", "  ")
+	expectedApplicationsPage := types.ApplicationsPage{Result: []types.Application{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedApplicationsPage, "", "  ")
 	jsonresponseForParams, _ := amino.MarshalJSONIndent(keeper.GetParams(context), "", "  ")
 	tests := []struct {
 		name  string

--- a/x/apps/query.go
+++ b/x/apps/query.go
@@ -10,8 +10,17 @@ import (
 	"github.com/tendermint/tendermint/rpc/client"
 )
 
-var customQuery = "custom/%s/%s"
+const customQuery = "custom/%s/%s"
 
+func checkPagination(page, limit int) (int, int) {
+	if page < 0 {
+		page = 1
+	}
+	if limit < 0 {
+		limit = 10000
+	}
+	return page, limit
+}
 func QueryApplication(cdc *codec.Codec, tmNode client.Client, addr sdk.Address, height int64) (types.Application, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
 	res, _, err := cliCtx.QueryStore(types.KeyForAppByAllApps(addr), types.StoreKey)
@@ -24,93 +33,97 @@ func QueryApplication(cdc *codec.Codec, tmNode client.Client, addr sdk.Address, 
 	return types.MustUnmarshalApplication(cdc, res), nil
 }
 
-func QueryApplications(cdc *codec.Codec, tmNode client.Client, height int64) (types.Applications, error) {
+func QueryApplications(cdc *codec.Codec, tmNode client.Client, height int64, page, limit int) (types.ApplicationsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryStakedApplicationsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ApplicationsPage{}, err
 	}
-	applications := types.Applications{}
+	ApplicationsPage := types.ApplicationsPage{}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryApplications), bz)
 	if err != nil {
-		return types.Applications{}, err
+		return types.ApplicationsPage{}, err
 	}
-	err = cdc.UnmarshalJSON(res, &applications)
+	err = cdc.UnmarshalJSON(res, &ApplicationsPage)
 	if err != nil {
-		return applications, err
+		return ApplicationsPage, err
 	}
 
-	return applications, nil
+	return ApplicationsPage, nil
 }
 
-func QueryStakedApplications(cdc *codec.Codec, tmNode client.Client, height int64) (types.Applications, error) {
+func QueryStakedApplications(cdc *codec.Codec, tmNode client.Client, height int64, page, limit int) (types.ApplicationsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryStakedApplicationsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ApplicationsPage{}, err
 	}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryStakedApplications), bz)
 	if err != nil {
-		return types.Applications{}, err
+		return types.ApplicationsPage{}, err
 	}
-	apps := types.Applications{}
-	err = cdc.UnmarshalJSON(res, &apps)
+	appsPage := types.ApplicationsPage{}
+	err = cdc.UnmarshalJSON(res, &appsPage)
 	if err != nil {
-		return apps, err
+		return appsPage, err
 	}
-	return apps, nil
+	return appsPage, nil
 }
 
-func QueryUnstakedApplications(cdc *codec.Codec, tmNode client.Client, height int64) (types.Applications, error) {
+func QueryUnstakedApplications(cdc *codec.Codec, tmNode client.Client, height int64, page, limit int) (types.ApplicationsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryStakedApplicationsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ApplicationsPage{}, err
 	}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryUnstakedApplications), bz)
 	if err != nil {
-		return types.Applications{}, err
+		return types.ApplicationsPage{}, err
 	}
-	apps := types.Applications{}
-	err = cdc.UnmarshalJSON(res, &apps)
+	appsPage := types.ApplicationsPage{}
+	err = cdc.UnmarshalJSON(res, &appsPage)
 	if err != nil {
-		return apps, err
+		return appsPage, err
 	}
-	return apps, nil
+	return appsPage, nil
 }
 
-func QueryUnstakingApplications(cdc *codec.Codec, tmNode client.Client, height int64) (types.Applications, error) {
+func QueryUnstakingApplications(cdc *codec.Codec, tmNode client.Client, height int64, page, limit int) (types.ApplicationsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryStakedApplicationsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ApplicationsPage{}, err
 	}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryUnstakingApplications), bz)
 	if err != nil {
-		return types.Applications{}, err
+		return types.ApplicationsPage{}, err
 	}
-	apps := types.Applications{}
-	err = cdc.UnmarshalJSON(res, &apps)
+	appsPage := types.ApplicationsPage{}
+	err = cdc.UnmarshalJSON(res, &appsPage)
 	if err != nil {
-		return apps, err
+		return appsPage, err
 	}
-	return apps, nil
+	return appsPage, nil
 }
 
 func QuerySupply(cdc *codec.Codec, tmNode client.Client, height int64) (stakedCoins sdk.Int, unstakedCoins sdk.Int, err error) {

--- a/x/apps/types/application.go
+++ b/x/apps/types/application.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -26,6 +27,17 @@ type ApplicationsPage struct {
 	Result Applications `json:"result"`
 	Total  int          `json:"total_pages"`
 	Page   int          `json:"page"`
+}
+
+// Marshals struct into JSON
+func (aP ApplicationsPage) JSON() (out []byte, err error) {
+	// each element should be a JSON
+	return json.Marshal(aP)
+}
+
+// String returns a human readable string representation of a validator page
+func (aP ApplicationsPage) String() string {
+	return fmt.Sprintf("Total:\t\t%d\nPage:\t\t%d\nResult:\t\t\n====\n%s\n====\n", aP.Total, aP.Page, aP.Result.String())
 }
 
 // NewApplication - initialize a new instance of an application

--- a/x/apps/types/application.go
+++ b/x/apps/types/application.go
@@ -3,8 +3,9 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"github.com/pokt-network/posmint/crypto"
 	"time"
+
+	"github.com/pokt-network/posmint/crypto"
 
 	sdk "github.com/pokt-network/posmint/types"
 )
@@ -19,6 +20,12 @@ type Application struct {
 	StakedTokens            sdk.Int          `json:"tokens" yaml:"tokens"`                 // tokens staked in the network
 	MaxRelays               sdk.Int          `json:"max_relays" yaml:"max_relays"`         // maximum number of relays allowed
 	UnstakingCompletionTime time.Time        `json:"unstaking_time" yaml:"unstaking_time"` // if unstaking, min time for the application to complete unstaking
+}
+
+type ApplicationsPage struct {
+	Result Applications `json:"result"`
+	Total  int          `json:"total_pages"`
+	Page   int          `json:"page"`
 }
 
 // NewApplication - initialize a new instance of an application

--- a/x/apps/types/applicationUtil.go
+++ b/x/apps/types/applicationUtil.go
@@ -3,11 +3,12 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/pokt-network/posmint/codec"
 	"github.com/pokt-network/posmint/crypto"
 	sdk "github.com/pokt-network/posmint/types"
-	"strings"
-	"time"
 )
 
 // Applications is a slice of type application.
@@ -22,7 +23,7 @@ func (a Applications) String() (out string) {
 
 // HashString returns a human readable string representation of a application.
 func (a Application) String() string {
-	return fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nChains:\t\t\t%v\nMaxRelays:\t\t%d\nStatus:\t\t\t%s\nTokens:\t\t\t%s\nUnstaking Time:\t%v",
+	return fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nChains:\t\t\t%v\nMaxRelays:\t\t%d\nStatus:\t\t\t%s\nTokens:\t\t\t%s\nUnstaking Time:\t%v\n----\n",
 		a.Address, a.PublicKey.RawString(), a.Jailed, a.Chains, a.MaxRelays.Int64(), a.Status, a.StakedTokens, a.UnstakingCompletionTime,
 	)
 }

--- a/x/apps/types/applicationUtil_test.go
+++ b/x/apps/types/applicationUtil_test.go
@@ -2,10 +2,11 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
+
 	"github.com/pokt-network/posmint/codec"
 	"github.com/pokt-network/posmint/crypto"
 	sdk "github.com/pokt-network/posmint/types"
-	"strings"
 
 	"fmt"
 	"math/rand"
@@ -82,7 +83,7 @@ func TestApplicationUtil_String(t *testing.T) {
 		{
 			name: "serializes applicaitons into string",
 			args: Applications{application},
-			want: fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nChains:\t\t\t%v\nMaxRelays:\t\t%d\nStatus:\t\t\t%s\nTokens:\t\t\t%s\nUnstaking Time:\t%v",
+			want: fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nChains:\t\t\t%v\nMaxRelays:\t\t%d\nStatus:\t\t\t%s\nTokens:\t\t\t%s\nUnstaking Time:\t%v\n----\n",
 				application.Address,
 				application.PublicKey.RawString(),
 				application.Jailed,

--- a/x/nodes/keeper/querier_test.go
+++ b/x/nodes/keeper/querier_test.go
@@ -1,14 +1,15 @@
 package keeper
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/pokt-network/pocket-core/x/nodes/types"
 	sdk "github.com/pokt-network/posmint/types"
 	"github.com/pokt-network/posmint/x/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/go-amino"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"reflect"
-	"testing"
 )
 
 func Test_NewQuerier(t *testing.T) {
@@ -30,7 +31,8 @@ func Test_NewQuerier(t *testing.T) {
 		Address: conAddress,
 	})
 
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Validator{}, "", "  ")
+	expectedValidatosPage := types.ValidatorsPage{Result: []types.Validator{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedValidatosPage, "", "  ")
 	jsonresponseSigningInfos, _ := amino.MarshalJSONIndent([]types.ValidatorSigningInfo{}, "", "  ")
 	jsonresponsestakedPool, _ := amino.MarshalJSONIndent(types.StakingPool(types.NewPool(sdk.ZeroInt())), "", "  ")
 	jsonresponseInt, _ := amino.MarshalJSONIndent("0", "", "  ")
@@ -382,7 +384,8 @@ func Test_queryStakedValidators(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Validator{}, "", "  ")
+	expectedValidatosPage := types.ValidatorsPage{Result: []types.Validator{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedValidatosPage, "", "  ")
 
 	tests := []struct {
 		name  string
@@ -457,7 +460,8 @@ func Test_queryUnstakedValidators(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Validator{}, "", "  ")
+	expectedValidatosPage := types.ValidatorsPage{Result: []types.Validator{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedValidatosPage, "", "  ")
 
 	tests := []struct {
 		name  string
@@ -499,7 +503,8 @@ func Test_queryUnstakingValidators(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Validator{}, "", "  ")
+	expectedValidatosPage := types.ValidatorsPage{Result: []types.Validator{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedValidatosPage, "", "  ")
 
 	tests := []struct {
 		name  string
@@ -580,7 +585,8 @@ func Test_queryValidators(t *testing.T) {
 		Page:  1,
 		Limit: 1,
 	})
-	jsonresponse, _ := amino.MarshalJSONIndent([]types.Validator{}, "", "  ")
+	expectedValidatosPage := types.ValidatorsPage{Result: []types.Validator{}, Total: 1, Page: 1}
+	jsonresponse, _ := amino.MarshalJSONIndent(expectedValidatosPage, "", "  ")
 
 	tests := []struct {
 		name  string

--- a/x/nodes/query.go
+++ b/x/nodes/query.go
@@ -21,6 +21,16 @@ const (
 	txHeightQuery      = "tx.height=%d"
 )
 
+func checkPagination(page, limit int) (int, int) {
+	if page < 0 {
+		page = 1
+	}
+	if limit < 0 {
+		limit = 10000
+	}
+	return page, limit
+}
+
 func QueryAccountBalance(cdc *codec.Codec, tmNode rpcclient.Client, addr sdk.Address, height int64) (sdk.Int, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
 	params := types.QueryAccountParams{Address: addr}
@@ -73,121 +83,99 @@ func QueryValidator(cdc *codec.Codec, tmNode rpcclient.Client, addr sdk.Address,
 	return types.MustUnmarshalValidator(cdc, res), nil
 }
 
-func QueryValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64) (types.Validators, error) {
+func QueryValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64, page, limit int) (types.ValidatorsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryStakedValidatorsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ValidatorsPage{}, err
 	}
-	validators := types.Validators{}
+	validatorsPage := types.ValidatorsPage{}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryValidators), bz)
 	if err != nil {
-		return validators, err
+		return validatorsPage, err
 	}
 
-	err = cdc.UnmarshalJSON(res, &validators)
+	err = cdc.UnmarshalJSON(res, &validatorsPage)
 	if err != nil {
-		return validators, err
+		return validatorsPage, err
 	}
 
-	return validators, nil
-	/*
-		paginate := func(objectLength, page, limit, defLimit) (start, end, pages, page int64) {
-			if page == 0 {
-				return -1, -1, -1, -1
-			} else if limit == 0 {
-				limit = defLimit
-			}
-
-			start = (page - 1) * limit
-			end = limit + start
-			pagesSize := end - start
-			pages = objectLength / pageSize
-
-			if end >= numObjs {
-			end = numObjs
-			}
-
-		if start >= numObjs {
-			return -1, -1, -1, -1
-		}
-
-		return start, end, pages, page
-		}
-		begin, end, page, totalPage = paginate(len(validators), begin, limit, defLimit)
-		return ValidatorsPage{validators[begin,end],totalPage, page}, nil
-	*/
+	return validatorsPage, nil
 }
 
-func QueryStakedValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64) (types.Validators, error) {
+func QueryStakedValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64, page, limit int) (types.ValidatorsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryStakedValidatorsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ValidatorsPage{}, err
 	}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryStakedValidators), bz)
 	if err != nil {
-		return types.Validators{}, err
+		return types.ValidatorsPage{}, err
 	}
-	validators := types.Validators{}
-	err = cdc.UnmarshalJSON(res, &validators)
+	validatorsPage := types.ValidatorsPage{}
+	err = cdc.UnmarshalJSON(res, &validatorsPage)
 	if err != nil {
-		return validators, err
+		return validatorsPage, err
 	}
-	return validators, nil
+	return validatorsPage, nil
 }
 
-func QueryUnstakedValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64) (types.Validators, error) {
+func QueryUnstakedValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64, page, limit int) (types.ValidatorsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryUnstakedValidatorsParams{
-		Page:  1,
-		Limit: 10000,
+		Page:  page,
+		Limit: limit,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ValidatorsPage{}, err
 	}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryUnstakedValidators), bz)
 	if err != nil {
-		return types.Validators{}, err
+		return types.ValidatorsPage{}, err
 	}
-	validators := types.Validators{}
-	err = cdc.UnmarshalJSON(res, &validators)
+	ValidatorsPage := types.ValidatorsPage{}
+	err = cdc.UnmarshalJSON(res, &ValidatorsPage)
 	if err != nil {
-		return validators, err
+		return ValidatorsPage, err
 	}
-	return validators, nil
+	return ValidatorsPage, nil
 }
 
-func QueryUnstakingValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64) (types.Validators, error) {
+func QueryUnstakingValidators(cdc *codec.Codec, tmNode rpcclient.Client, height int64, page, limit int) (types.ValidatorsPage, error) {
 	cliCtx := util.NewCLIContext(tmNode, nil, "").WithCodec(cdc).WithHeight(height)
+	page, limit = checkPagination(page, limit)
 	params := types.QueryUnstakingValidatorsParams{
 		Page:  1,
 		Limit: 10000,
 	}
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {
-		return nil, err
+		return types.ValidatorsPage{}, err
 	}
 	res, _, err := cliCtx.QueryWithData(fmt.Sprintf(customQuery, types.StoreKey, types.QueryUnstakingValidators), bz)
 	if err != nil {
-		return types.Validators{}, err
+		return types.ValidatorsPage{}, err
 	}
-	validators := types.Validators{}
-	err = cdc.UnmarshalJSON(res, &validators)
+	validatorsPage := types.ValidatorsPage{}
+	err = cdc.UnmarshalJSON(res, &validatorsPage)
 	if err != nil {
-		return validators, err
+		return validatorsPage, err
 	}
-	return validators, nil
+	return validatorsPage, nil
 }
 
 func QuerySigningInfo(cdc *codec.Codec, tmNode rpcclient.Client, height int64, consAddr sdk.Address) (types.ValidatorSigningInfo, error) {

--- a/x/nodes/query_test.go
+++ b/x/nodes/query_test.go
@@ -1,13 +1,14 @@
 package nodes
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/pokt-network/pocket-core/x/nodes/types"
 	"github.com/pokt-network/posmint/codec"
 	sdk "github.com/pokt-network/posmint/types"
 	"github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
-	"reflect"
-	"testing"
 )
 
 func TestQueryAccountBalance(t *testing.T) {

--- a/x/nodes/query_test.go
+++ b/x/nodes/query_test.go
@@ -230,7 +230,7 @@ func TestQueryStakedValidators(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryStakedValidators(tt.args.cdc, tt.args.tmNode, tt.args.height)
+			got, err := QueryStakedValidators(tt.args.cdc, tt.args.tmNode, tt.args.height, 1, 1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryStakedValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -328,7 +328,7 @@ func TestQueryUnstakedValidators(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryUnstakedValidators(tt.args.cdc, tt.args.tmNode, tt.args.height)
+			got, err := QueryUnstakedValidators(tt.args.cdc, tt.args.tmNode, tt.args.height, 1, 1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryUnstakedValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -360,7 +360,7 @@ func TestQueryUnstakingValidators(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryUnstakingValidators(tt.args.cdc, tt.args.tmNode, tt.args.height)
+			got, err := QueryUnstakingValidators(tt.args.cdc, tt.args.tmNode, tt.args.height, 1, 1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryUnstakingValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -426,7 +426,7 @@ func TestQueryValidators(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryValidators(tt.args.cdc, tt.args.tmNode, tt.args.height)
+			got, err := QueryValidators(tt.args.cdc, tt.args.tmNode, tt.args.height, 1, 1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/x/nodes/query_test.go
+++ b/x/nodes/query_test.go
@@ -235,8 +235,8 @@ func TestQueryStakedValidators(t *testing.T) {
 				t.Errorf("QueryStakedValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("QueryStakedValidators() got = %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(len(got.Result), len(tt.want)) {
+				t.Errorf("QueryStakedValidators() got = %v, want %v", got.Result, tt.want)
 			}
 		})
 	}
@@ -333,7 +333,7 @@ func TestQueryUnstakedValidators(t *testing.T) {
 				t.Errorf("QueryUnstakedValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(len(got.Result), len(tt.want)) {
 				t.Errorf("QueryUnstakedValidators() got = %v, want %v", got, tt.want)
 			}
 		})
@@ -365,7 +365,7 @@ func TestQueryUnstakingValidators(t *testing.T) {
 				t.Errorf("QueryUnstakingValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(len(got.Result), len(tt.want)) {
 				t.Errorf("QueryUnstakingValidators() got = %v, want %v", got, tt.want)
 			}
 		})
@@ -431,7 +431,7 @@ func TestQueryValidators(t *testing.T) {
 				t.Errorf("QueryValidators() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(len(got.Result), len(tt.want)) {
 				t.Errorf("QueryValidators() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/x/nodes/types/valUtil.go
+++ b/x/nodes/types/valUtil.go
@@ -3,11 +3,12 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/pokt-network/posmint/codec"
 	"github.com/pokt-network/posmint/crypto"
 	sdk "github.com/pokt-network/posmint/types"
-	"strings"
-	"time"
 )
 
 // Validators is a collection of Validator
@@ -22,8 +23,8 @@ func (v Validators) String() (out string) {
 
 // HashString returns a human readable string representation of a validator.
 func (v Validator) String() string {
-	return fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nStatus:\t\t\t%s\nTokens:\t\t\t%s\n"+
-		"ServiceURL:\t\t%s\nChains:\t\t\t%v\nUnstaking Completion Time:\t\t%v",
+	return fmt.Sprintf("\nAddress:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nStatus:\t\t\t%s\nTokens:\t\t\t%s\n"+
+		"ServiceURL:\t\t%s\nChains:\t\t\t%v\nUnstaking Completion Time:\t\t%v\n----\n",
 		v.Address, v.PublicKey.RawString(), v.Jailed, v.Status, v.StakedTokens, v.ServiceURL, v.Chains, v.UnstakingCompletionTime,
 	)
 }

--- a/x/nodes/types/valUtil.go
+++ b/x/nodes/types/valUtil.go
@@ -23,8 +23,9 @@ func (v Validators) String() (out string) {
 
 // HashString returns a human readable string representation of a validator.
 func (v Validator) String() string {
-	return fmt.Sprintf("\nAddress:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nStatus:\t\t\t%s\nTokens:\t\t\t%s\n"+
-		"ServiceURL:\t\t%s\nChains:\t\t\t%v\nUnstaking Completion Time:\t\t%v\n----\n",
+	return fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nStatus:\t\t\t%s\nTokens:\t\t\t%s\n"+
+		"ServiceURL:\t\t%s\nChains:\t\t\t%v\nUnstaking Completion Time:\t\t%v"+
+		"\n----\n",
 		v.Address, v.PublicKey.RawString(), v.Jailed, v.Status, v.StakedTokens, v.ServiceURL, v.Chains, v.UnstakingCompletionTime,
 	)
 }

--- a/x/nodes/types/valUtil_test.go
+++ b/x/nodes/types/valUtil_test.go
@@ -3,13 +3,14 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pokt-network/posmint/crypto"
-	sdk "github.com/pokt-network/posmint/types"
-	"github.com/tendermint/go-amino"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/pokt-network/posmint/crypto"
+	sdk "github.com/pokt-network/posmint/types"
+	"github.com/tendermint/go-amino"
 )
 
 func TestValidators_JSON(t *testing.T) {
@@ -76,12 +77,14 @@ func TestValidators_String(t *testing.T) {
 		wantOut string
 	}{
 		{"String Test", v, fmt.Sprintf("Address:\t\t%s\nPublic Key:\t\t%s\nJailed:\t\t\t%v\nStatus:\t\t\t%s\nTokens:\t\t\t%s\n"+
-			"ServiceURL:\t\t%s\nChains:\t\t\t%v\nUnstaking Completion Time:\t\t%v",
+			"ServiceURL:\t\t%s\nChains:\t\t\t%v\nUnstaking Completion Time:\t\t%v"+
+			"\n----",
 			sdk.Address(pub.Address()), pub.RawString(), false, sdk.Staked, sdk.ZeroInt(), "google.com", []string{"b60d7bdd334cd3768d43f14a05c7fe7e886ba5bcb77e1064530052fed1a3f145"}, time.Unix(0, 0).UTC(),
 		)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
 			if gotOut := tt.v.String(); gotOut != tt.wantOut {
 				t.Errorf("String() = \n%v \nwant \b%v", gotOut, tt.wantOut)
 			}

--- a/x/nodes/types/validator.go
+++ b/x/nodes/types/validator.go
@@ -36,6 +36,11 @@ func (vP ValidatorsPage) JSON() (out []byte, err error) {
 	return json.Marshal(vP)
 }
 
+// String returns a human readable string representation of a validator page
+func (vP ValidatorsPage) String() string {
+	return fmt.Sprintf("Total:\t\t%d\nPage:\t\t%d\nResult:\t\t\n====\n%s\n====\n", vP.Total, vP.Page, vP.Result.String())
+}
+
 // NewValidator - initialize a new validator
 func NewValidator(addr sdk.Address, consPubKey crypto.PublicKey, chains []string, serviceURL string, tokensToStake sdk.Int) Validator {
 	return Validator{

--- a/x/nodes/types/validator.go
+++ b/x/nodes/types/validator.go
@@ -3,8 +3,9 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"github.com/pokt-network/posmint/crypto"
 	"time"
+
+	"github.com/pokt-network/posmint/crypto"
 
 	sdk "github.com/pokt-network/posmint/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -20,6 +21,12 @@ type Validator struct {
 	ServiceURL              string           `json:"service_url" yaml:"service_url"`       // url where the pocket service api is hosted
 	StakedTokens            sdk.Int          `json:"tokens" yaml:"tokens"`                 // tokens staked in the network
 	UnstakingCompletionTime time.Time        `json:"unstaking_time" yaml:"unstaking_time"` // if unstaking, min time for the validator to complete unstaking
+}
+
+type ValidatorsPage struct {
+	Result Validators `json:"result"`
+	Total  int        `json:"total_pages"`
+	Page   int        `json:"page"`
 }
 
 // NewValidator - initialize a new validator

--- a/x/nodes/types/validator.go
+++ b/x/nodes/types/validator.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -27,6 +28,12 @@ type ValidatorsPage struct {
 	Result Validators `json:"result"`
 	Total  int        `json:"total_pages"`
 	Page   int        `json:"page"`
+}
+
+// Marshals struct into JSON
+func (vP ValidatorsPage) JSON() (out []byte, err error) {
+	// each element should be a JSON
+	return json.Marshal(vP)
 }
 
 // NewValidator - initialize a new validator


### PR DESCRIPTION
Close #658 

Adds pagination to All possible applications & nodes queries on both RPC & CLI interfaces.

It will return pages in this standard
```
Result : []validators/applications
Page: int (current page)
Total: (total_amount_of_pages)
```

NOTE: @pokt-network/app-solutions Changes current structure for RPC calls.