### PR TITLE
add off chain simualtion for relays

### DIFF
--- a/app/cmd/cli/root.go
+++ b/app/cmd/cli/root.go
@@ -21,6 +21,7 @@ var (
 	pocketRPCPort   string
 	blockTime       int
 	testnet         bool
+	simulateRelay   bool
 )
 
 var CLIVersion = fmt.Sprintf("%s", app.AppVersion)
@@ -56,6 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&pocketRPCPort, "pocketRPCPort", "", "the port for pocket rpc")
 	rootCmd.PersistentFlags().IntVar(&blockTime, "blockTime", 1, "how often should the network create blocks")
 	rootCmd.PersistentFlags().BoolVar(&testnet, "testnet", false, "would you like to connect to Pocket Network testnet")
+	rootCmd.PersistentFlags().BoolVar(&simulateRelay, "simulateRelay", false, "would you like to be able to test your relays")
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(version)
@@ -68,7 +70,7 @@ var startCmd = &cobra.Command{
 	Long:  `Starts the Pocket node, picks up the config from the assigned <datadir>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		tmNode := app.InitApp(datadir, tmNode, persistentPeers, seeds, tmRPCPort, tmPeersPort)
-		go rpc.StartRPC(app.GlobalConfig.PocketConfig.RPCPort)
+		go rpc.StartRPC(app.GlobalConfig.PocketConfig.RPCPort, simulateRelay)
 		// trap kill signals (2,3,15,9)
 		signalChannel := make(chan os.Signal, 1)
 		signal.Notify(signalChannel,

--- a/app/cmd/rpc/client.go
+++ b/app/cmd/rpc/client.go
@@ -1,12 +1,17 @@
 package rpc
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/pokt-network/pocket-core/app"
 	"github.com/pokt-network/pocket-core/x/pocketcore/types"
-	"net/http"
 )
 
 func Dispatch(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -105,4 +110,66 @@ func SendRawTx(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		return
 	}
 	WriteResponse(w, string(j), r.URL.Path, r.Host)
+}
+
+type simRelayParams struct {
+	Url     string        `json:"chain_url"`
+	Payload types.Payload `json:"payload"` // the data payload of the request
+}
+
+func SimRequest(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if !cors(&w, r) {
+		return
+	}
+	var params = simRelayParams{}
+	if err := PopModel(w, r, ps, &params); err != nil {
+		WriteErrorResponse(w, 400, err.Error())
+		return
+	}
+	// retrieve the hosted blockchain url requested
+	url := strings.Trim(params.Url, `/`)
+	if len(params.Payload.Path) > 0 {
+		url = url + "/" + strings.Trim(params.Payload.Path, `/`)
+	}
+	// do basic http request on the relay
+	res, er := executeHTTPRequest(params.Payload.Data, url, params.Payload.Method, params.Payload.Headers)
+
+	if er != nil {
+		WriteErrorResponse(w, 400, er.Error())
+		return
+	}
+	WriteResponse(w, string(res), r.URL.Path, r.Host)
+}
+
+func executeHTTPRequest(payload string, url string, method string, headers map[string]string) (string, error) {
+	// generate an http request
+	req, err := http.NewRequest(method, url, bytes.NewBuffer([]byte(payload)))
+	if err != nil {
+		return "", err
+	}
+	// add headers if needed
+	if len(headers) == 0 {
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+	}
+	// execute the request
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return payload, err
+	}
+	// ensure code is 200
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("Expected Code 200 from Request got %v", resp.StatusCode)
+	}
+	// read all bz
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	// return
+	return string(body), nil
 }

--- a/app/cmd/rpc/server.go
+++ b/app/cmd/rpc/server.go
@@ -14,8 +14,19 @@ import (
 
 var APIVersion = fmt.Sprintf("%s", app.AppVersion)
 
-func StartRPC(port string) {
-	log.Fatal(http.ListenAndServe(":"+port, Router(GetRoutes())))
+func StartRPC(port string, simulation bool) {
+	routes := GetRoutes()
+	if simulation {
+		var simIdx int
+		for i := range routes {
+			if routes[i].Name == "SimulateRequest" {
+				simIdx = i
+				break
+			}
+		}
+		routes = append(routes[:simIdx], routes[simIdx:]...)
+	}
+	log.Fatal(http.ListenAndServe(":"+port, Router(routes)))
 }
 
 func Router(routes Routes) *httprouter.Router {
@@ -74,6 +85,7 @@ func GetRoutes() Routes {
 		Route{Name: "QueryUpgrade", Method: "POST", Path: "/v1/query/upgrade", HandlerFunc: Upgrade},
 		Route{Name: "QueryACL", Method: "POST", Path: "/v1/query/acl", HandlerFunc: ACL},
 		Route{Name: "QueryState", Method: "GET", Path: "/v1/query/state", HandlerFunc: State},
+		Route{Name: "SimulateRequest", Method: "POST", Path: "/v1/client/sim", HandlerFunc: SimRequest},
 	}
 	return routes
 }

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -70,3 +70,5 @@
 - Changed receipt structure (added evidence type)
 - Change `querySupplyResponse` struct to use `totalStaked`, `totalUnstaked` & `Total` as `*big.Int` due to memory overflow
 - Added RPC SPEC doc in yaml and json with swagger support
+- Add off chain relay RPC for testing purposes, wont' create proof & does not affect validator
+- Add flag to to simulate relays, default false.

--- a/x/pocketcore/keeper/service.go
+++ b/x/pocketcore/keeper/service.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"encoding/hex"
 	"fmt"
+
 	pc "github.com/pokt-network/pocket-core/x/pocketcore/types"
 	sdk "github.com/pokt-network/posmint/types"
 )

--- a/x/pocketcore/types/service.go
+++ b/x/pocketcore/types/service.go
@@ -5,14 +5,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	appexported "github.com/pokt-network/pocket-core/x/apps/exported"
-	nodeexported "github.com/pokt-network/pocket-core/x/nodes/exported"
-	"github.com/pokt-network/posmint/crypto"
-	sdk "github.com/pokt-network/posmint/types"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"strings"
+
+	appexported "github.com/pokt-network/pocket-core/x/apps/exported"
+	nodeexported "github.com/pokt-network/pocket-core/x/nodes/exported"
+	"github.com/pokt-network/posmint/crypto"
+	sdk "github.com/pokt-network/posmint/types"
 )
 
 const DEFAULTHTTPMETHOD = "POST"


### PR DESCRIPTION
Close #698 

Add `/client/sim` RPC call to test chain requests. Has no effect on the validator rewards or chain status.

by default endpoint is disabled, use flag `--simulateRelay true` to enable.