### PR TITLE
log mint errors, allow visibility into errors

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -18,6 +18,7 @@
 - Updated POSMint to have 1 msg and 1 signature per tx
 - Change ClaimSubmissionWindow and BlocksPerSession call on getPseudorandomIndex to use the session context
 - Changed getPseudorandomIndex add a new parameter for sessionCtx
+- log mint errors
 
 ## RC-0.3.0
 - Added governance module from posmint

--- a/x/nodes/keeper/reward.go
+++ b/x/nodes/keeper/reward.go
@@ -55,10 +55,12 @@ func (k Keeper) mint(ctx sdk.Ctx, amount sdk.Int, address sdk.Address) sdk.Resul
 	coins := sdk.NewCoins(sdk.NewCoin(k.StakeDenom(ctx), amount))
 	mintErr := k.AccountKeeper.MintCoins(ctx, types.StakedPoolName, coins)
 	if mintErr != nil {
+		ctx.Logger().Error(mintErr.Error())
 		return mintErr.Result()
 	}
 	sendErr := k.AccountKeeper.SendCoinsFromModuleToAccount(ctx, types.StakedPoolName, address, coins)
 	if sendErr != nil {
+		ctx.Logger().Error(mintErr.Error())
 		return sendErr.Result()
 	}
 	logString := fmt.Sprintf("a reward of %s was minted to %s", amount.String(), address.String())


### PR DESCRIPTION
Close #834, Having this log allows visibility to the minting mechanism.