### PR TITLE
Added Configurable Timeouts to HTTP Server/Client

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	AppVersion = "RC-0.5.0"
+	AppVersion = "RC-0.5.0-T"
 )
 
 // NewPocketCoreApp is a constructor function for PocketCoreApp

--- a/app/cmd/cli/queryUtil.go
+++ b/app/cmd/cli/queryUtil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/pokt-network/pocket-core/x/pocketcore/types"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -101,6 +102,7 @@ func init() {
 func QueryRPC(path string, jsonArgs []byte) (string, error) {
 	//cliURL := app.GlobalConfig.PocketConfig.RemoteCLIURL + ":" + app.GlobalConfig.PocketConfig.RPCPort + path
 	cliURL := app.GlobalConfig.PocketConfig.RemoteCLIURL + path
+	types.SetRPCTimeout(app.GlobalConfig.PocketConfig.RPCTimeout)
 	fmt.Println(cliURL)
 	req, err := http.NewRequest("POST", cliURL, bytes.NewBuffer(jsonArgs))
 	if err != nil {
@@ -108,7 +110,7 @@ func QueryRPC(path string, jsonArgs []byte) (string, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{
-		Timeout: 120 * time.Millisecond,
+		Timeout: types.GetRPCTimeout() * time.Millisecond,
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/app/cmd/cli/queryUtil.go
+++ b/app/cmd/cli/queryUtil.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/pokt-network/pocket-core/app"
 	"github.com/pokt-network/pocket-core/app/cmd/rpc"
@@ -106,7 +107,9 @@ func QueryRPC(path string, jsonArgs []byte) (string, error) {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 120 * time.Millisecond,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/app/cmd/cli/root.go
+++ b/app/cmd/cli/root.go
@@ -79,7 +79,7 @@ var startCmd = &cobra.Command{
 			genesisType = app.TestnetGenesisType
 		}
 		tmNode := app.InitApp(datadir, tmNode, persistentPeers, seeds, remoteCLIURL, keybase, genesisType)
-		go rpc.StartRPC(app.GlobalConfig.PocketConfig.RPCPort, simulateRelay)
+		go rpc.StartRPC(app.GlobalConfig.PocketConfig.RPCPort, app.GlobalConfig.PocketConfig.RPCTimeout, simulateRelay)
 		// trap kill signals (2,3,15,9)
 		signalChannel := make(chan os.Signal, 1)
 		signal.Notify(signalChannel,

--- a/app/cmd/rpc/client.go
+++ b/app/cmd/rpc/client.go
@@ -164,7 +164,7 @@ func executeHTTPRequest(payload string, url string, method string, headers map[s
 		}
 	}
 	// execute the request
-	resp, err := (&http.Client{Timeout: 120 * time.Millisecond}).Do(req)
+	resp, err := (&http.Client{Timeout: types.GetRPCTimeout() * time.Millisecond}).Do(req)
 	if err != nil {
 		return payload, err
 	}

--- a/app/cmd/rpc/client.go
+++ b/app/cmd/rpc/client.go
@@ -5,12 +5,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/julienschmidt/httprouter"
-	"github.com/pokt-network/pocket-core/app"
-	"github.com/pokt-network/pocket-core/x/pocketcore/types"
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/pokt-network/pocket-core/app"
+	"github.com/pokt-network/pocket-core/x/pocketcore/types"
 )
 
 // Dispatch supports CORS functionality
@@ -162,7 +164,7 @@ func executeHTTPRequest(payload string, url string, method string, headers map[s
 		}
 	}
 	// execute the request
-	resp, err := (&http.Client{}).Do(req)
+	resp, err := (&http.Client{Timeout: 120 * time.Millisecond}).Do(req)
 	if err != nil {
 		return payload, err
 	}

--- a/app/cmd/rpc/common_test.go
+++ b/app/cmd/rpc/common_test.go
@@ -51,7 +51,7 @@ func NewInMemoryTendermintNode(t *testing.T, genesisState []byte) (tendermintNod
 	assert.NotNil(t, tendermintNode)
 	assert.NotNil(t, keybase)
 	// init cache in memory
-	pocketTypes.InitConfig("", "data", "data", dbm.MemDBBackend, dbm.MemDBBackend, 100, 100, "pocket_evidence", "session")
+	pocketTypes.InitConfig("", "data", "data", dbm.MemDBBackend, dbm.MemDBBackend, 100, 100, "pocket_evidence", "session", 3000)
 	pocketTypes.InitClientBlockAllowance(1000)
 	// start the in memory node
 	err := tendermintNode.Start()

--- a/app/cmd/rpc/server.go
+++ b/app/cmd/rpc/server.go
@@ -20,7 +20,15 @@ func StartRPC(port string, timeout int64, simulation bool) {
 		simRoute := Route{Name: "SimulateRequest", Method: "POST", Path: "/v1/client/sim", HandlerFunc: SimRequest}
 		routes = append(routes, simRoute)
 	}
-	log.Fatal(http.ListenAndServe(":"+port, http.TimeoutHandler(Router(routes), time.Duration(timeout)*time.Millisecond, "Server Timeout Handling Request")))
+
+	srv := &http.Server{
+		ReadTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 20 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		Addr:              ":" + port,
+		Handler:           http.TimeoutHandler(Router(routes), time.Duration(timeout)*time.Millisecond, "Server Timeout Handling Request"),
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 func Router(routes Routes) *httprouter.Router {

--- a/app/cmd/rpc/server.go
+++ b/app/cmd/rpc/server.go
@@ -3,24 +3,24 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/julienschmidt/httprouter"
+	"github.com/pokt-network/pocket-core/app"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
-
-	"github.com/julienschmidt/httprouter"
-	"github.com/pokt-network/pocket-core/app"
+	"time"
 )
 
 var APIVersion = app.AppVersion
 
-func StartRPC(port string, simulation bool) {
+func StartRPC(port string, timeout int64, simulation bool) {
 	routes := GetRoutes()
 	if simulation {
 		simRoute := Route{Name: "SimulateRequest", Method: "POST", Path: "/v1/client/sim", HandlerFunc: SimRequest}
 		routes = append(routes, simRoute)
 	}
-	log.Fatal(http.ListenAndServe(":"+port, Router(routes)))
+	log.Fatal(http.ListenAndServe(":"+port, http.TimeoutHandler(Router(routes), time.Duration(timeout)*time.Millisecond, "Server Timeout Handling Request")))
 }
 
 func Router(routes Routes) *httprouter.Router {

--- a/app/common_test.go
+++ b/app/common_test.go
@@ -53,7 +53,7 @@ func NewInMemoryTendermintNode(t *testing.T, genesisState []byte) (tendermintNod
 	assert.NotNil(t, tendermintNode)
 	assert.NotNil(t, keybase)
 	// init cache in memory
-	pocketTypes.InitConfig("", "data", "data", dbm.MemDBBackend, dbm.MemDBBackend, 100, 100, "pocket_evidence", "session")
+	pocketTypes.InitConfig("", "data", "data", dbm.MemDBBackend, dbm.MemDBBackend, 100, 100, "pocket_evidence", "session", 3000)
 	// start the in memory node
 	err := tendermintNode.Start()
 	if err != nil {

--- a/app/config.go
+++ b/app/config.go
@@ -74,6 +74,7 @@ const (
 	DefaultUserAgent                = ""
 	DefaultValidatorCacheSize       = 500
 	DefaultApplicationCacheSize     = DefaultValidatorCacheSize
+	DefaultRPCTimeout               = 3000
 )
 
 var (
@@ -114,6 +115,7 @@ type PocketConfig struct {
 	UserAgent                string            `json:"user_agent"`
 	ValidatorCacheSize       int64             `json:"validator_cache_size"`
 	ApplicationCacheSize     int64             `json:"application_cache_size"`
+	RPCTimeout               int64             `json:"rpc_timeout"`
 }
 
 type GenesisType int
@@ -146,6 +148,7 @@ func DefaultConfig(dataDir string) Config {
 			UserAgent:                DefaultUserAgent,
 			ValidatorCacheSize:       DefaultValidatorCacheSize,
 			ApplicationCacheSize:     DefaultApplicationCacheSize,
+			RPCTimeout:               DefaultRPCTimeout,
 		},
 	}
 	c.TendermintConfig.SetRoot(dataDir)
@@ -371,7 +374,7 @@ func InitKeyfiles() {
 }
 
 func InitPocketCoreConfig() {
-	types.InitConfig(GlobalConfig.PocketConfig.UserAgent, GlobalConfig.PocketConfig.DataDir, GlobalConfig.PocketConfig.DataDir, GlobalConfig.PocketConfig.SessionDBType, GlobalConfig.PocketConfig.EvidenceDBType, GlobalConfig.PocketConfig.MaxEvidenceCacheEntires, GlobalConfig.PocketConfig.MaxSessionCacheEntries, GlobalConfig.PocketConfig.EvidenceDBName, GlobalConfig.PocketConfig.SessionDBName)
+	types.InitConfig(GlobalConfig.PocketConfig.UserAgent, GlobalConfig.PocketConfig.DataDir, GlobalConfig.PocketConfig.DataDir, GlobalConfig.PocketConfig.SessionDBType, GlobalConfig.PocketConfig.EvidenceDBType, GlobalConfig.PocketConfig.MaxEvidenceCacheEntires, GlobalConfig.PocketConfig.MaxSessionCacheEntries, GlobalConfig.PocketConfig.EvidenceDBName, GlobalConfig.PocketConfig.SessionDBName, GlobalConfig.PocketConfig.RPCTimeout)
 	types.InitClientBlockAllowance(GlobalConfig.PocketConfig.ClientBlockSyncAllowance)
 	types.InitJSONSorting(GlobalConfig.PocketConfig.JSONSortRelayResponses)
 	nodesTypes.InitConfig(GlobalConfig.PocketConfig.ValidatorCacheSize)

--- a/app/tx_test.go
+++ b/app/tx_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	pocketTypes.ClearSessionCache()
 	pocketTypes.ClearEvidence()
 	// init cache in memory
-	pocketTypes.InitConfig("", "data", "data", db.MemDBBackend, db.MemDBBackend, 100, 100, "pocket_evidence", "session")
+	pocketTypes.InitConfig("", "data", "data", db.MemDBBackend, db.MemDBBackend, 100, 100, "pocket_evidence", "session", 3000)
 	m.Run()
 	os.Exit(0)
 }

--- a/x/pocketcore/keeper/common_test.go
+++ b/x/pocketcore/keeper/common_test.go
@@ -170,7 +170,7 @@ func createTestInput(t *testing.T, isCheckTx bool) (sdk.Ctx, []nodesTypes.Valida
 	defaultPocketParams := types.DefaultParams()
 	defaultPocketParams.SupportedBlockchains = []string{getTestSupportedBlockchain()}
 	keeper.SetParams(ctx, defaultPocketParams)
-	types.InitConfig("", "data", "data", dbm.MemDBBackend, dbm.MemDBBackend, 100, 100, "pocket_evidence", "session")
+	types.InitConfig("", "data", "data", dbm.MemDBBackend, dbm.MemDBBackend, 100, 100, "pocket_evidence", "session", 3000)
 	return ctx, vals, ap, accs, keeper, keys, kb
 }
 

--- a/x/pocketcore/types/cache_test.go
+++ b/x/pocketcore/types/cache_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func InitCacheTest() {
-	InitConfig("", "data", "data", db.MemDBBackend, db.MemDBBackend, 100, 100, "pocket_evidence", "session")
+	InitConfig("", "data", "data", db.MemDBBackend, db.MemDBBackend, 100, 100, "pocket_evidence", "session", 3000)
 }
 
 func TestMain(m *testing.M) {

--- a/x/pocketcore/types/config.go
+++ b/x/pocketcore/types/config.go
@@ -3,14 +3,22 @@ package types
 import (
 	"fmt"
 	db "github.com/tendermint/tm-db"
+	"time"
+)
+
+const (
+	DefaultRPCTimeout = 3000
+	MaxRPCTimeout     = 1000000
+	MinRPCTimeout     = 1
 )
 
 var (
-	globalUserAgent string
+	globalUserAgent  string
+	globalRPCTimeout time.Duration
 )
 
 // "InitConfig" - Initializes the cache for sessions and evidence
-func InitConfig(userAgent, evidenceDir, sessionDir string, sessionDBType, evidenceDBType db.DBBackendType, maxEvidenceEntries, maxSessionEntries int, evidenceDBName, sessionDBName string) {
+func InitConfig(userAgent, evidenceDir, sessionDir string, sessionDBType, evidenceDBType db.DBBackendType, maxEvidenceEntries, maxSessionEntries int, evidenceDBName, sessionDBName string, timeout int64) {
 	cacheOnce.Do(func() {
 		globalEvidenceCache = new(CacheStorage)
 		globalSessionCache = new(CacheStorage)
@@ -18,6 +26,7 @@ func InitConfig(userAgent, evidenceDir, sessionDir string, sessionDBType, eviden
 		globalSessionCache.Init(sessionDir, sessionDBName, sessionDBType, maxSessionEntries)
 	})
 	globalUserAgent = userAgent
+	SetRPCTimeout(timeout)
 }
 
 func FlushCache() {
@@ -29,4 +38,17 @@ func FlushCache() {
 	if err != nil {
 		fmt.Printf("unable to flush evidence to the database before shutdown!! %s\n", err.Error())
 	}
+}
+
+func GetRPCTimeout() time.Duration {
+	return globalRPCTimeout
+}
+
+func SetRPCTimeout(timeout int64) {
+
+	if timeout < MinRPCTimeout || timeout > MaxRPCTimeout {
+		timeout = DefaultRPCTimeout
+	}
+
+	globalRPCTimeout = time.Duration(timeout)
 }

--- a/x/pocketcore/types/service.go
+++ b/x/pocketcore/types/service.go
@@ -5,14 +5,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	appexported "github.com/pokt-network/pocket-core/x/apps/exported"
-	nodeexported "github.com/pokt-network/pocket-core/x/nodes/exported"
-	"github.com/pokt-network/posmint/crypto"
-	sdk "github.com/pokt-network/posmint/types"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
+	"time"
+
+	appexported "github.com/pokt-network/pocket-core/x/apps/exported"
+	nodeexported "github.com/pokt-network/pocket-core/x/nodes/exported"
+	"github.com/pokt-network/posmint/crypto"
+	sdk "github.com/pokt-network/posmint/types"
 )
 
 const DEFAULTHTTPMETHOD = "POST"
@@ -296,7 +298,9 @@ func executeHTTPRequest(payload, url, userAgent string, basicAuth BasicAuth, met
 		}
 	}
 	// execute the request
-	resp, err := (&http.Client{}).Do(req)
+	resp, err := (&http.Client{
+		Timeout: 100 * time.Millisecond,
+	}).Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/x/pocketcore/types/service.go
+++ b/x/pocketcore/types/service.go
@@ -298,9 +298,7 @@ func executeHTTPRequest(payload, url, userAgent string, basicAuth BasicAuth, met
 		}
 	}
 	// execute the request
-	resp, err := (&http.Client{
-		Timeout: 100 * time.Millisecond,
-	}).Do(req)
+	resp, err := (&http.Client{Timeout: GetRPCTimeout() * time.Millisecond}).Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Adding rpc_timeout Parameter under config.json. 

It should be an integer between 1 and 1,000,000 denoting the amount of ms (milliseconds) for request to wait before timeout for the RPC layer and http client. 

If the number is lower or higher than the value specified we use a default value of 3000 ms which should be enough for most use cases.

Closes #1066 