### PR TITLE
Add deterministic builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       # Run tests
       - run:
          name: 'test'
-         command: make test_shot
+         command: make test_short
          no_output_timeout: 20m
   # Job to trigger the Pocket Core deployments CI with a specific branch
   trigger-pocket-core-deployments-branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       # static analyzer
       - run: go vet ./...
       # Build the binary
-      - run: make build
+      - run: go build app/cmd/pocket_core/main.go
       # Cache build
       - save_cache:
           key: pocket-core-build-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       # static analyzer
       - run: go vet ./...
       # Build the binary
-      - run: go build app/cmd/pocket_core/main.go
+      - run: make build
       # Cache build
       - save_cache:
           key: pocket-core-build-{{ .Environment.CIRCLE_SHA1 }}
@@ -47,7 +47,7 @@ jobs:
       # Run tests
       - run:
          name: 'test'
-         command: go test -short -p 1 ./...
+         command: make test_shot
          no_output_timeout: 20m
   # Job to trigger the Pocket Core deployments CI with a specific branch
   trigger-pocket-core-deployments-branches:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+#!/usr/bin/make -f
+
+GOVERSION=go1.13.15
+CURRENTVERSION=$(go version | awk '${print $3}')
+INSTALL_PATH?=${GOPATH}/bin/pocket
+BUILD_TAGS?='cleveldb'
+export GO111MODULE = on
+
+
+all: test_short install
+
+## Build
+build: go.sum
+	@echo "--> Building pocket core 🏗"
+	@CGO_ENABLED=1 go build -mod=readonly -tags $(BUILD_TAGS) ./...
+
+build_race: go.sum
+	@echo "--> Building pocket core 🏗"
+	@CGO_ENABLED=1 go build -mod=readonly -race -tags $(BUILD_TAGS) ./...
+
+install: go.sum
+	@echo "--> Building pocket core 🏗"
+	@CGO_ENABLED=1 go build -tags $(BUILD_TAGS) -o $(INSTALL_PATH) ./app/cmd/pocket_core/main.go
+	@echo "--> Done 🚀🌕"
+
+install_unsafe:
+	@echo "--> ️This is building an unverified golang version; use at own risk! ⚠"
+	@echo "--> Building pocket core 🏗"
+	CGO_ENABLED=1 go build -tags $(BUILD_TAGS) -o $(INSTALL_PATH) ./app/cmd/pocket_core/main.go
+	@echo "--> Done 🚀🌕"
+
+go.sum: check
+	@echo "--> Ensure dependencies have not been modified 🔍"
+	@go mod verify
+	@go mod tidy
+.PHONY: go.sum 
+
+check: 
+ifneq ($(GOVERSION), $(CURRENTVERSION))
+	@echo "Go version does not match, please install ${GOVERSION} 💥"
+	exit 1
+endif
+
+go-mod-cache: go.sum
+	@echo "--> Download go modules to local cache 📦"
+	@go mod download
+.PHONY: go-mod-cache
+
+### Testing
+test:
+	@echo "--> running all tests 📝"
+	@go test -mod=readonly -p 1 ./...
+
+test_short:
+	@echo "--> running short tests 📝"
+	@go test -mod=readonly -short -p 1 ./...
+
+test_race:
+	@echo "--> running tests with race 📝"
+	@go test -mod=readonly -race -p 1 ./...
+
+test_short_race:
+	@echo "--> running short tests with race 📝"
+	@go test -mod=readonly -short -race -p 1 ./...
+
+.PHONY:	test \
+test_race

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 GOVERSION=go1.13.15
-CURRENTVERSION=$(go version | awk '${print $3}')
+CURRENTVERSION=$(shell (go version | awk '{print $$3}'))
 INSTALL_PATH?=${GOPATH}/bin/pocket
 BUILD_TAGS?='cleveldb'
 export GO111MODULE = on
@@ -18,7 +18,7 @@ build_race: go.sum
 	@echo "--> Building pocket core 🏗"
 	@CGO_ENABLED=1 go build -mod=readonly -race -tags $(BUILD_TAGS) ./...
 
-install: go.sum
+install: check go.sum 
 	@echo "--> Building pocket core 🏗"
 	@CGO_ENABLED=1 go build -tags $(BUILD_TAGS) -o $(INSTALL_PATH) ./app/cmd/pocket_core/main.go
 	@echo "--> Done 🚀🌕"
@@ -29,15 +29,18 @@ install_unsafe:
 	CGO_ENABLED=1 go build -tags $(BUILD_TAGS) -o $(INSTALL_PATH) ./app/cmd/pocket_core/main.go
 	@echo "--> Done 🚀🌕"
 
-go.sum: check
+go.sum: 
 	@echo "--> Ensure dependencies have not been modified 🔍"
 	@go mod verify
 	@go mod tidy
 .PHONY: go.sum 
 
 check: 
+	@echo "--> Verifying current Go version 🔍"
 ifneq ($(GOVERSION), $(CURRENTVERSION))
 	@echo "Go version does not match, please install ${GOVERSION} 💥"
+	@echo $(CURRENTVERSION) 
+	@echo $(GOVERSION)
 	exit 1
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ all: test_short install
 ## Build
 build: go.sum
 	@echo "--> Building pocket core 🏗"
-	@CGO_ENABLED=1 go build -mod=readonly -tags $(BUILD_TAGS) ./...
+	@CGO_ENABLED=1 go build -mod=readonly -tags $(BUILD_TAGS) ./app/cmd/pocket_core/main.go
 
 build_race: go.sum
 	@echo "--> Building pocket core 🏗"
-	@CGO_ENABLED=1 go build -mod=readonly -race -tags $(BUILD_TAGS) ./...
+	@CGO_ENABLED=1 go build -mod=readonly -race -tags $(BUILD_TAGS) ./app/cmd/pocket_core/main.go
 
 install: check go.sum 
 	@echo "--> Building pocket core 🏗"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pokt-network/pocket-core
 
-go 1.13.15
+go 1.13
 
 require (
 	github.com/go-kit/kit v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pokt-network/pocket-core
 
-go 1.13
+go 1.13.15
 
 require (
 	github.com/go-kit/kit v0.10.0


### PR DESCRIPTION
Increase go version to 1.13.15

Use a makefile to ensure
- dependencies
- Golang version
- Build flags

Close #1074

Ideally we want to make sure all distributions for pocket-core use this standarized build @pokt-network/infrastructure 