### PR TITLE
Client nodes should validate transactions before submitting

### DIFF
--- a/x/pocketcore/keeper/proof.go
+++ b/x/pocketcore/keeper/proof.go
@@ -51,6 +51,10 @@ func (k Keeper) SendProofTx(ctx sdk.Ctx, n client.Client, proofTx func(cliCtx ut
 		}
 		// get the merkle proof object for the pseudorandom index
 		mProof, leaf := evidence.GenerateMerkleProof(int(index))
+		if !mProof.Validate(claim.MerkleRoot, leaf, claim.TotalProofs) {
+			ctx.Logger().Error(fmt.Sprintf("produced invalid proof for pending claim for app: %s, at sessionHeight: %d", claim.ApplicationPubKey, claim.SessionBlockHeight))
+			continue
+		}
 		// generate the auto txbuilder and clictx
 		txBuilder, cliCtx, err := newTxBuilderAndCliCtx(ctx, pc.MsgProof{}, n, kp, k)
 		if err != nil {


### PR DESCRIPTION
Out of the last 100 blocks, about 80% of the proofs submitted are generating code 66, invalid merkle proof. While I think invalid proofs are relatively uncommon, valid proofs are never resubmitted after they confirm, while invalid proofs are resubmitted each block. This is increasing the number of transactions nodes must validate considerably, and raising the CPU and RAM requirements for block validation.

This commit doesn't solve the underlying problem - I haven't figured out why invalid proofs are being generated in the first place. It simply has the client check its own proof before submitting, so they don't have to pay the fee for an invalid transaction, and the rest of the network doesn't have to process the invalid proof. If widely adopted, I believe this will significantly reduce the CPU requirements for running a node.

This doesn't fully resolve #1094, but it should reduce the impact on the network, so I would advocate adopting it quickly.