### PR TITLE
Add Beta tags to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ workflows:
             tags:
               only:
                 - /^RC-.*/
+                - /^Beta-.*/
                 - /^stable-.*/
             branches:
               ignore: /.*/
@@ -122,6 +123,7 @@ workflows:
             tags:
               only:
                 - /^RC-.*/
+                - /^Beta-.*/
                 - /^stable-.*/
             branches:
               ignore: /.*/
@@ -132,6 +134,7 @@ workflows:
             tags:
               only:
                 - /^RC-.*/
+                - /^Beta-.*/
                 - /^stable-.*/
             branches:
               ignore: /.*/


### PR DESCRIPTION
This PR allow Beta-* tags to trigger pocket-core-deployments' pipeline