### PR TITLE
Basic stop endpoint and cmd implementation.

### DIFF
--- a/app/cmd/cli/queryUtil.go
+++ b/app/cmd/cli/queryUtil.go
@@ -38,7 +38,8 @@ var (
 	GetBlockTxsPath,
 	GetSupplyPath,
 	GetAllParamsPath,
-	GetParamPath string
+	GetParamPath,
+	GetStopPath string
 )
 
 func init() {
@@ -93,6 +94,8 @@ func init() {
 			GetAllParamsPath = route.Path
 		case "QueryParam":
 			GetParamPath = route.Path
+		case "Stop":
+			GetStopPath = route.Path
 		default:
 			continue
 		}

--- a/app/cmd/cli/root.go
+++ b/app/cmd/cli/root.go
@@ -65,6 +65,7 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(version)
+	rootCmd.AddCommand(stopCmd)
 }
 
 // startCmd represents the start command
@@ -146,5 +147,20 @@ var version = &cobra.Command{
 	Long:  `Retrieves the version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("AppVersion: %s\n", CLIVersion)
+	},
+}
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop pocket-core",
+	Long:  `Stop pocket-core`,
+	Run: func(cmd *cobra.Command, args []string) {
+		app.InitConfig(datadir, tmNode, persistentPeers, seeds, remoteCLIURL)
+		res, err := QueryRPC(GetStopPath, []byte{})
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		fmt.Println(res)
 	},
 }

--- a/app/cmd/cli/root.go
+++ b/app/cmd/cli/root.go
@@ -156,7 +156,7 @@ var stopCmd = &cobra.Command{
 	Long:  `Stop pocket-core`,
 	Run: func(cmd *cobra.Command, args []string) {
 		app.InitConfig(datadir, tmNode, persistentPeers, seeds, remoteCLIURL)
-		res, err := QueryRPC(GetStopPath, []byte{})
+		res, err := QuerySecuredRPC(GetStopPath, []byte{}, app.GetAuthTokenFromFile())
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/app/cmd/rpc/client.go
+++ b/app/cmd/rpc/client.go
@@ -74,16 +74,21 @@ func Relay(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
 // Stop
 func Stop(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	app.ShutdownPocketCore()
-	err := app.PCA.TMNode().Stop()
-	if err != nil {
-		fmt.Println(err)
-		WriteErrorResponse(w, 400, err.Error())
-		fmt.Println("Force Stop , PID:" + fmt.Sprint(os.Getpid()))
-		os.Exit(1)
+	value := r.URL.Query().Get("authtoken")
+	if value == app.AuthToken.Value {
+		app.ShutdownPocketCore()
+		err := app.PCA.TMNode().Stop()
+		if err != nil {
+			fmt.Println(err)
+			WriteErrorResponse(w, 400, err.Error())
+			fmt.Println("Force Stop , PID:" + fmt.Sprint(os.Getpid()))
+			os.Exit(1)
+		}
+		fmt.Println("Stop Successful, PID:" + fmt.Sprint(os.Getpid()))
+		os.Exit(0)
+	} else {
+		WriteErrorResponse(w, 401, "wrong authtoken "+value)
 	}
-	fmt.Println("Stop Successful, PID:" + fmt.Sprint(os.Getpid()))
-	os.Exit(0)
 }
 
 // Challenge supports CORS functionality

--- a/app/cmd/rpc/client.go
+++ b/app/cmd/rpc/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -69,6 +70,20 @@ func Relay(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		return
 	}
 	WriteJSONResponse(w, string(j), r.URL.Path, r.Host)
+}
+
+// Stop
+func Stop(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	app.ShutdownPocketCore()
+	err := app.PCA.TMNode().Stop()
+	if err != nil {
+		fmt.Println(err)
+		WriteErrorResponse(w, 400, err.Error())
+		fmt.Println("Force Stop , PID:" + fmt.Sprint(os.Getpid()))
+		os.Exit(1)
+	}
+	fmt.Println("Stop Successful, PID:" + fmt.Sprint(os.Getpid()))
+	os.Exit(0)
 }
 
 // Challenge supports CORS functionality

--- a/app/cmd/rpc/server.go
+++ b/app/cmd/rpc/server.go
@@ -26,15 +26,15 @@ func StartRPC(port string, timeout int64, simulation bool, debug bool) {
 	}
 
 	if debug {
-		routes = append(routes, Route{Name: "DebugIndex", Method: "GET", Path: "/debug/pprof", HandlerFunc: wrapperHandlerFunc(pprof.Index)})
+		routes = append(routes, Route{Name: "DebugBlock", Method: "GET", Path: "/debug/pprof/block", HandlerFunc: wrapperHandler(pprof.Handler(("block")))})
 		routes = append(routes, Route{Name: "DebugCmd", Method: "GET", Path: "/debug/pprof/cmdline", HandlerFunc: wrapperHandlerFunc(pprof.Cmdline)})
-		routes = append(routes, Route{Name: "DebugProfile", Method: "GET", Path: "/debug/pprof/profile", HandlerFunc: wrapperHandlerFunc(pprof.Profile)})
-		routes = append(routes, Route{Name: "DebugSymbol", Method: "GET", Path: "/debug/pprof/symbol", HandlerFunc: wrapperHandlerFunc(pprof.Symbol)})
-		routes = append(routes, Route{Name: "DebugTrace", Method: "GET", Path: "/debug/pprof/trace", HandlerFunc: wrapperHandlerFunc(pprof.Trace)})
 		routes = append(routes, Route{Name: "DebugGoroutine", Method: "GET", Path: "/debug/pprof/goroutine", HandlerFunc: wrapperHandler(pprof.Handler(("goroutine")))})
 		routes = append(routes, Route{Name: "DebugHeap", Method: "GET", Path: "/debug/pprof/heap", HandlerFunc: wrapperHandler(pprof.Handler(("heap")))})
+		routes = append(routes, Route{Name: "DebugIndex", Method: "GET", Path: "/debug/pprof", HandlerFunc: wrapperHandlerFunc(pprof.Index)})
+		routes = append(routes, Route{Name: "DebugProfile", Method: "GET", Path: "/debug/pprof/profile", HandlerFunc: wrapperHandlerFunc(pprof.Profile)})
+		routes = append(routes, Route{Name: "DebugSymbol", Method: "GET", Path: "/debug/pprof/symbol", HandlerFunc: wrapperHandlerFunc(pprof.Symbol)})
 		routes = append(routes, Route{Name: "DebugThreadCreate", Method: "GET", Path: "/debug/pprof/threadcreate", HandlerFunc: wrapperHandler(pprof.Handler(("threadcreate")))})
-		routes = append(routes, Route{Name: "DebugBlock", Method: "GET", Path: "/debug/pprof/block", HandlerFunc: wrapperHandler(pprof.Handler(("block")))})
+		routes = append(routes, Route{Name: "DebugTrace", Method: "GET", Path: "/debug/pprof/trace", HandlerFunc: wrapperHandlerFunc(pprof.Trace)})
 		routes = append(routes, Route{Name: "FreeOsMemory", Method: "GET", Path: "/debug/freememory", HandlerFunc: FreeMemory})
 		routes = append(routes, Route{Name: "MemStats", Method: "GET", Path: "/debug/memstats", HandlerFunc: MemStats})
 	}
@@ -76,37 +76,38 @@ type Routes []Route
 func GetRoutes() Routes {
 	routes := Routes{
 		Route{Name: "AppVersion", Method: "GET", Path: "/v1", HandlerFunc: Version},
-		Route{Name: "HandleDispatch", Method: "POST", Path: "/v1/client/dispatch", HandlerFunc: Dispatch},
-		Route{Name: "HandleDispatchCORS", Method: "OPTIONS", Path: "/v1/client/dispatch", HandlerFunc: Dispatch},
-		Route{Name: "Service", Method: "POST", Path: "/v1/client/relay", HandlerFunc: Relay},
-		Route{Name: "ServiceCORS", Method: "OPTIONS", Path: "/v1/client/relay", HandlerFunc: Relay},
 		Route{Name: "Challenge", Method: "POST", Path: "/v1/client/challenge", HandlerFunc: Challenge},
 		Route{Name: "ChallengeCORS", Method: "OPTIONS", Path: "/v1/client/challenge", HandlerFunc: Challenge},
+		Route{Name: "HandleDispatch", Method: "POST", Path: "/v1/client/dispatch", HandlerFunc: Dispatch},
+		Route{Name: "HandleDispatchCORS", Method: "OPTIONS", Path: "/v1/client/dispatch", HandlerFunc: Dispatch},
 		Route{Name: "SendRawTx", Method: "POST", Path: "/v1/client/rawtx", HandlerFunc: SendRawTx},
-		Route{Name: "QueryBlock", Method: "POST", Path: "/v1/query/block", HandlerFunc: Block},
-		Route{Name: "QueryTX", Method: "POST", Path: "/v1/query/tx", HandlerFunc: Tx},
-		Route{Name: "QueryAccountTxs", Method: "POST", Path: "/v1/query/accounttxs", HandlerFunc: AccountTxs},
-		Route{Name: "QueryBlockTxs", Method: "POST", Path: "/v1/query/blocktxs", HandlerFunc: BlockTxs},
-		Route{Name: "QueryHeight", Method: "POST", Path: "/v1/query/height", HandlerFunc: Height},
-		Route{Name: "QueryBalance", Method: "POST", Path: "/v1/query/balance", HandlerFunc: Balance},
+		Route{Name: "Service", Method: "POST", Path: "/v1/client/relay", HandlerFunc: Relay},
+		Route{Name: "Stop", Method: "POST", Path: "/v1/private/stop", HandlerFunc: Stop},
+		Route{Name: "ServiceCORS", Method: "OPTIONS", Path: "/v1/client/relay", HandlerFunc: Relay},
 		Route{Name: "QueryAccount", Method: "POST", Path: "/v1/query/account", HandlerFunc: Account},
-		Route{Name: "QueryNodes", Method: "POST", Path: "/v1/query/nodes", HandlerFunc: Nodes},
-		Route{Name: "QueryNode", Method: "POST", Path: "/v1/query/node", HandlerFunc: Node},
-		Route{Name: "QueryNodeParams", Method: "POST", Path: "/v1/query/nodeparams", HandlerFunc: NodeParams},
-		Route{Name: "QueryNodeClaims", Method: "POST", Path: "/v1/query/nodeclaims", HandlerFunc: NodeClaims},
-		Route{Name: "QueryNodeClaim", Method: "POST", Path: "/v1/query/nodeclaim", HandlerFunc: NodeClaim},
-		Route{Name: "QueryApps", Method: "POST", Path: "/v1/query/apps", HandlerFunc: Apps},
-		Route{Name: "QueryApp", Method: "POST", Path: "/v1/query/app", HandlerFunc: App},
-		Route{Name: "QueryAppParams", Method: "POST", Path: "/v1/query/appparams", HandlerFunc: AppParams},
-		Route{Name: "QueryPocketParams", Method: "POST", Path: "/v1/query/pocketparams", HandlerFunc: PocketParams},
-		Route{Name: "QuerySupportedChains", Method: "POST", Path: "/v1/query/supportedchains", HandlerFunc: SupportedChains},
-		Route{Name: "QuerySupply", Method: "POST", Path: "/v1/query/supply", HandlerFunc: Supply},
-		Route{Name: "QueryDAOOwner", Method: "POST", Path: "/v1/query/daoowner", HandlerFunc: DAOOwner},
-		Route{Name: "QueryUpgrade", Method: "POST", Path: "/v1/query/upgrade", HandlerFunc: Upgrade},
+		Route{Name: "QueryAccountTxs", Method: "POST", Path: "/v1/query/accounttxs", HandlerFunc: AccountTxs},
 		Route{Name: "QueryACL", Method: "POST", Path: "/v1/query/acl", HandlerFunc: ACL},
 		Route{Name: "QueryAllParams", Method: "POST", Path: "/v1/query/allparams", HandlerFunc: AllParams},
+		Route{Name: "QueryApp", Method: "POST", Path: "/v1/query/app", HandlerFunc: App},
+		Route{Name: "QueryAppParams", Method: "POST", Path: "/v1/query/appparams", HandlerFunc: AppParams},
+		Route{Name: "QueryApps", Method: "POST", Path: "/v1/query/apps", HandlerFunc: Apps},
+		Route{Name: "QueryBalance", Method: "POST", Path: "/v1/query/balance", HandlerFunc: Balance},
+		Route{Name: "QueryBlock", Method: "POST", Path: "/v1/query/block", HandlerFunc: Block},
+		Route{Name: "QueryBlockTxs", Method: "POST", Path: "/v1/query/blocktxs", HandlerFunc: BlockTxs},
+		Route{Name: "QueryDAOOwner", Method: "POST", Path: "/v1/query/daoowner", HandlerFunc: DAOOwner},
+		Route{Name: "QueryHeight", Method: "POST", Path: "/v1/query/height", HandlerFunc: Height},
+		Route{Name: "QueryNode", Method: "POST", Path: "/v1/query/node", HandlerFunc: Node},
+		Route{Name: "QueryNodeClaim", Method: "POST", Path: "/v1/query/nodeclaim", HandlerFunc: NodeClaim},
+		Route{Name: "QueryNodeClaims", Method: "POST", Path: "/v1/query/nodeclaims", HandlerFunc: NodeClaims},
+		Route{Name: "QueryNodeParams", Method: "POST", Path: "/v1/query/nodeparams", HandlerFunc: NodeParams},
+		Route{Name: "QueryNodes", Method: "POST", Path: "/v1/query/nodes", HandlerFunc: Nodes},
 		Route{Name: "QueryParam", Method: "POST", Path: "/v1/query/param", HandlerFunc: Param},
+		Route{Name: "QueryPocketParams", Method: "POST", Path: "/v1/query/pocketparams", HandlerFunc: PocketParams},
 		Route{Name: "QueryState", Method: "POST", Path: "/v1/query/state", HandlerFunc: State},
+		Route{Name: "QuerySupply", Method: "POST", Path: "/v1/query/supply", HandlerFunc: Supply},
+		Route{Name: "QuerySupportedChains", Method: "POST", Path: "/v1/query/supportedchains", HandlerFunc: SupportedChains},
+		Route{Name: "QueryTX", Method: "POST", Path: "/v1/query/tx", HandlerFunc: Tx},
+		Route{Name: "QueryUpgrade", Method: "POST", Path: "/v1/query/upgrade", HandlerFunc: Upgrade},
 	}
 	return routes
 }

--- a/app/config.go
+++ b/app/config.go
@@ -787,7 +787,7 @@ func InitAuthToken() {
 func GetAuthTokenFromFile() sdk.AuthToken {
 	t := sdk.AuthToken{}
 	datadir := GlobalConfig.PocketConfig.DataDir
-	configFilepath := datadir + string(fp.Separator) + sdk.ConfigDirName + string(fp.Separator) + sdk.AuthFileName
+	configFilepath := datadir + FS + sdk.ConfigDirName + FS + sdk.AuthFileName
 
 	var jsonFile *os.File
 	defer jsonFile.Close()

--- a/types/config.go
+++ b/types/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/tendermint/tendermint/config"
 	db "github.com/tendermint/tm-db"
 	"sync"
+	"time"
 )
 
 // TmConfig is the structure that holds the SDK configuration parameters.
@@ -47,6 +48,11 @@ type Config struct {
 	PocketConfig     PocketConfig  `json:"pocket_config"`
 }
 
+type AuthToken struct {
+	Value  string
+	Issued time.Time
+}
+
 const (
 	DefaultDDName                     = ".pocket"
 	DefaultKeybaseName                = "pocket-keybase"
@@ -84,6 +90,7 @@ const (
 	DefaultCtxCacheSize               = 20
 	DefaultABCILogging                = false
 	DefaultRelayErrors                = true
+	AuthFileName                      = "auth.json"
 )
 
 func DefaultConfig(dataDir string) Config {


### PR DESCRIPTION
Basic implementation for stop cmd/endpoint.

Utility command to stop pocket. 

Basic usage:

`pocket stop`

or

`curl --location --request POST 'http://localhost:8081/v1/private/stop'`

