### PR TITLE
[Fix][Pocket-core] Wait for the child process to terminate before the parent (two processes launch mode)

### DIFF
--- a/app/cmd/cli/root_test.go
+++ b/app/cmd/cli/root_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitOnStopSignals(t *testing.T) {
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	}()
+
+	sig := <-waitOnStopSignals()
+	require.Equal(t, sig, syscall.SIGTERM)
+}


### PR DESCRIPTION
The aim of this PR is to gracefully shutdown the pocket core program when started with two processes. This reinforces the resilience of the program following the stop signals (SIGTERM, SIGINT,SIGQUIT,SIGKILL) sent by the kernel.