### PR TITLE
Change build instructions to match go 1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Use "pocket [command] --help" for more information about a command.
 
 ### Installation
 
-Clone the repository and run `go build pocket-core/app/cmd/pocket_core/main.go`
+Clone the repository, `cd` into it and run `go build app/cmd/pocket_core/main.go`
 
 ## Documentation
 


### PR DESCRIPTION
go 1.1.6 is module aware by default now, which means it will look for `go.mod` in the directory where it's run and, missing that, parent directories. The result of the previous instructions is an error: pocket-core/app/cmd/pocket_core/main.go:4:2: no required module provides package github.com/pokt-network/pocket-core/app/cmd/cli: go.mod file not found in current directory or any parent directory; see 'go help modules'