### PR TITLE
custom tx indexer

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	AppVersion = "RC-0.6.1"
+	AppVersion = "RC-0.6.2"
 )
 
 // NewPocketCoreApp is a constructor function for PocketCoreApp

--- a/app/cmd/cli/util.go
+++ b/app/cmd/cli/util.go
@@ -112,7 +112,7 @@ var exportGenesisForReset = &cobra.Command{
 			fmt.Println("error parsing height: ", err)
 			return
 		}
-		db, err := app.OpenDB(app.GlobalConfig)
+		db, err := app.OpenApplicationDB(app.GlobalConfig)
 		if err != nil {
 			fmt.Println("error loading application database: ", err)
 			return
@@ -172,7 +172,7 @@ var unsafeRollbackCmd = &cobra.Command{
 			fmt.Println("error parsing height: ", err)
 			return
 		}
-		db, err := app.OpenDB(app.GlobalConfig)
+		db, err := app.OpenApplicationDB(app.GlobalConfig)
 		if err != nil {
 			fmt.Println("error loading application database: ", err)
 			return

--- a/app/cmd/rpc/common_test.go
+++ b/app/cmd/rpc/common_test.go
@@ -183,6 +183,7 @@ func inMemTendermintNode(genesisState []byte) (*node.Node, keys.Keybase) {
 	dbProvider := func(*node.DBContext) (dbm.DB, error) {
 		return db, nil
 	}
+	txDB := dbm.NewMemDB()
 	baseapp := creator(c.Logger, db, io.Writer(nil))
 	tmNode, err := node.NewNode(baseapp,
 		c.TmConfig,
@@ -190,6 +191,7 @@ func inMemTendermintNode(genesisState []byte) (*node.Node, keys.Keybase) {
 		privVal,
 		&nodeKey,
 		proxy.NewLocalClientCreator(baseapp),
+		sdk.NewTransactionIndexer(txDB),
 		genDocProvider,
 		dbProvider,
 		node.DefaultMetricsProvider(c.TmConfig.Instrumentation),

--- a/app/common_test.go
+++ b/app/common_test.go
@@ -245,12 +245,14 @@ func inMemTendermintNode(genesisState []byte) (*node.Node, keys.Keybase) {
 		return db, nil
 	}
 	app := GetApp(c.Logger, db, traceWriter)
+	txDB := dbm.NewMemDB()
 	tmNode, err := node.NewNode(app.BaseApp,
 		c.TmConfig,
 		0,
 		privVal,
 		&nodeKey,
 		proxy.NewLocalClientCreator(app),
+		sdk.NewTransactionIndexer(txDB),
 		genDocProvider,
 		dbProvider,
 		node.DefaultMetricsProvider(c.TmConfig.Instrumentation),

--- a/app/query.go
+++ b/app/query.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	messageSenderQuery     = "message.sender='%s'"
-	transferRecipientQuery = "transfer.recipient='%s'"
+	messageSenderQuery     = "tx.signer='%s'"
+	transferRecipientQuery = "tx.recipient='%s'"
 	txHeightQuery          = "tx.height=%d"
 )
 
@@ -55,7 +55,7 @@ func (app PocketCoreApp) QueryAccountTxs(addr string, page, perPage int, prove b
 	}
 	query := fmt.Sprintf(messageSenderQuery, addr)
 	page, perPage = checkPagination(page, perPage)
-	res, err = tmClient.ReducedTxSearch(query, prove, page, perPage, checkSort(sort))
+	res, err = tmClient.TxSearch(query, prove, page, perPage, checkSort(sort))
 	return
 }
 func (app PocketCoreApp) QueryRecipientTxs(addr string, page, perPage int, prove bool, sort string) (res *core_types.ResultTxSearch, err error) {
@@ -67,7 +67,7 @@ func (app PocketCoreApp) QueryRecipientTxs(addr string, page, perPage int, prove
 	}
 	query := fmt.Sprintf(transferRecipientQuery, addr)
 	page, perPage = checkPagination(page, perPage)
-	res, err = tmClient.ReducedTxSearch(query, prove, page, perPage, checkSort(sort))
+	res, err = tmClient.TxSearch(query, prove, page, perPage, checkSort(sort))
 	return
 }
 
@@ -76,7 +76,7 @@ func (app PocketCoreApp) QueryBlockTxs(height int64, page, perPage int, prove bo
 	defer func() { _ = tmClient.Stop() }()
 	query := fmt.Sprintf(txHeightQuery, height)
 	page, perPage = checkPagination(page, perPage)
-	res, err = tmClient.ReducedTxSearch(query, prove, page, perPage, checkSort(sort))
+	res, err = tmClient.TxSearch(query, prove, page, perPage, checkSort(sort))
 	return
 }
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,9 @@
+## RC-0.6.2
+- Implemented a Custom Transaction Indexer
+- Return AllClaims if no address is passed to nodeClaims query
+- No ABCI query during newTx() function in pocket core module
+- Change StdSignature from Base64 to Hex in RPC
+
 ## RC-0.6.1
 - Fixed RelaysToTokensMultiplier bug
 - Added utility CLI command to convert evidence from amino to protobuf

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 - Return AllClaims if no address is passed to nodeClaims query
 - No ABCI query during newTx() function in pocket core module
 - Change StdSignature from Base64 to Hex in RPC
+- Added config to drop events from account and blocktxs
 
 ## RC-0.6.1
 - Fixed RelaysToTokensMultiplier bug

--- a/doc/rpc-spec.yaml
+++ b/doc/rpc-spec.yaml
@@ -323,13 +323,17 @@ paths:
       tags:
         - query
       requestBody:
-        description: Returns all transactions sent by the address
+        description: Returns all transactions sent by the address; Max per_page = 1000, sort can be "asc" or (Default) "desc"
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/QueryAccountTXs'
             example:
               address: '197e4d46009879f28f978a90627c7dfeab64b4777afcc24e2b9c3d72b4dada22'
+              height: 99
+              page: 1
+              per_page: 1000
+              sort: "desc"
         required: true
       responses:
         '200':
@@ -604,13 +608,16 @@ paths:
       tags:
         - query
       requestBody:
-        description: Returns all transactions at a certain block height
+        description: Returns all transactions at a certain block height; Max per_page = 1000, sort can be "asc" or (Default) "desc"
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/QueryBlockTXs'
             example:
               height: 99
+              page: 1
+              per_page: 1000
+              sort: "desc"
         required: true
       responses:
         '200':
@@ -1810,18 +1817,20 @@ components:
           type: string
         info:
           type: string
-        gas_wanted:
-          type: integer
-          format: int64
-        gas_used:
-          type: integer
-          format: int64
         events:
           type: array
           items:
             type: string
         codespace:
           type: string
+        signer:
+          type: string
+        recipient:
+          type: string
+          description: The receiver of the transaction, will be null if no receiver
+        message_type:
+          type: string
+          description: The type of the transaction, can be "app_stake", "app_begin_unstake", "stake_validator", "begin_unstake_validator", "unjail_validator", "send", "upgrade", "change_param", "dao_tranfer", "claim", or "proof"
     TXProof:
       type: object
       description: Proof of the transaction

--- a/doc/software specific architecture.md
+++ b/doc/software specific architecture.md
@@ -98,5 +98,29 @@ In order to reduce network bandwidth and ensure consistent successful delivery o
 
 This algorithm ensures an efficient offset caluclation and an equal distribution of automatic transactions.
 
+### TXIndexer
+Pocket Core uses a custom transaction indexer for optimal usage of resources. Tendermint's default TxIndexer paginates
+and sorts transactions during time of query, resulting in a large consumption of resources. Tendermint's default TxIndexer
+also relies on events to index transactions, and due to a bug in RC-0.5.X pocket core module events are all concatenated
+together. This makes indexing a nightmare.
+
+**Custom Indexer**
+Since LevelDB comparators order lexicongraphically, the implementation uses ELEN to encode numbers to ensure alphanumerical
+ordering at insertion time. https://www.zanopha.com/docs/elen.pdf
+Since the keys are sorted alphanumerically from the start, we don't have to:
+    - Load all results to memory 
+    - Paginate and sort transactions after
+This indexer inserts in sorted order so it can paginate and return based on the db iterator resulting in a significant 
+reduction in resource consumption
+
+The custom pocket core transaction indexer also reduces the scope of the Search() functionality to optimize strictly for 
+the following use cases:
+    - BlockTxs (Get transactions at a certain height)
+    - AccountTxs (Get transactions for a certain account (sent and received))
+    
+The custom pocket core transaction indexer also injects the message_type into the struct to provide an easier method of 
+parsing the transactions. `json:"message_type"`
+
+
 
 

--- a/doc/user guide.md
+++ b/doc/user guide.md
@@ -34,7 +34,7 @@ Pocket Core is software for Pocket Network 'node runners'. This software impleme
 #### Checkout the [latest release](https://github.com/pokt-network/pocket-core/releases)
 `git checkout tags/<release tag>`
 
-Example: *git checkout tags/RC-0.6.1*
+Example: *git checkout tags/RC-0.6.2*
 
 #### Build
 
@@ -45,7 +45,7 @@ Example: *go build -o $GOPATH/bin/pocket $GOPATH/src/github.com/pok-network/pock
 #### Test installation
 ```
 $ pocket version
-> RC-0.6.1
+> RC-0.6.2
 ```
 ### From Homebrew
 `brew tap pokt-network/pocket-core && brew install pokt-network/pocket-core/pocket`
@@ -53,7 +53,7 @@ $ pocket version
 #### Test installation
 ```
 $ pocket version
-> RC-0.6.1
+> RC-0.6.2
 ```
 ### From Deployment Artifact
 See [pokt-network/pocket-core-deployments](https://github.com/pokt-network/pocket-core-deployments)

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.5
 )
 
-replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20210427132315-229f7197433a // indirect
+replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20210427155510-04e1c67f3eed // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.0
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/jordanorelli/lexnum v0.0.0-20141216151731-460eeb125754
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
@@ -26,4 +27,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.5
 )
 
-replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20210318025232-505fa50f49b5
+replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20210427132315-229f7197433a // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jordanorelli/lexnum v0.0.0-20141216151731-460eeb125754 h1:ovgRFhVUYZWz6KnWPrnV7HBxrK0ErOeyXtlVvh0Rr5k=
+github.com/jordanorelli/lexnum v0.0.0-20141216151731-460eeb125754/go.mod h1:f1WdQhB98V35bULPsZUMFP9U1XWhpaHrO6myMijgMhU=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -296,6 +298,18 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pokt-network/tendermint v0.32.11-0.20210318025232-505fa50f49b5 h1:nWR5tdxUf00LfOnR1PXoBEG/nTtNEAZG8IWYJoWJJ74=
 github.com/pokt-network/tendermint v0.32.11-0.20210318025232-505fa50f49b5/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210426235727-6f6f06ee1a80 h1:xLi3wGVf5Un6GvYq9xCd6izShjtvBs4zlIjHimk0ZDs=
+github.com/pokt-network/tendermint v0.32.11-0.20210426235727-6f6f06ee1a80/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210427000741-d9d2e8323042 h1:YlzGhJJAg5ZRGqzS/c3pYPOxWTQ5tFXJRoECLBEkdEg=
+github.com/pokt-network/tendermint v0.32.11-0.20210427000741-d9d2e8323042/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210427001526-00eddafb188d h1:gzP74Ir1rgXsfT1QOzY40R9OuMbHxWY6Mnz8wv7K/ZU=
+github.com/pokt-network/tendermint v0.32.11-0.20210427001526-00eddafb188d/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210427003049-624f6d230340 h1:ufDWIHnUeduKooDNPD6BwM2iP56mgevlZLVF6mUL/6M=
+github.com/pokt-network/tendermint v0.32.11-0.20210427003049-624f6d230340/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210427004717-65ebc239c879 h1:fSL2E7bibYI6Hm4t+9HE1Z7R8u3Gl66VpiEUWsxSc7k=
+github.com/pokt-network/tendermint v0.32.11-0.20210427004717-65ebc239c879/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210427132315-229f7197433a h1:Ztv1CAGqlHzC4XEFvln26Bdh/yJiJQsDXsF7AD62Dc8=
+github.com/pokt-network/tendermint v0.32.11-0.20210427132315-229f7197433a/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/pokt-network/tendermint v0.32.11-0.20210427004717-65ebc239c879 h1:fSL
 github.com/pokt-network/tendermint v0.32.11-0.20210427004717-65ebc239c879/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
 github.com/pokt-network/tendermint v0.32.11-0.20210427132315-229f7197433a h1:Ztv1CAGqlHzC4XEFvln26Bdh/yJiJQsDXsF7AD62Dc8=
 github.com/pokt-network/tendermint v0.32.11-0.20210427132315-229f7197433a/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
+github.com/pokt-network/tendermint v0.32.11-0.20210427155510-04e1c67f3eed h1:viQQSd19s4C4nTtFdCRJHm44a9IjW63Vs1oAqZItqSA=
+github.com/pokt-network/tendermint v0.32.11-0.20210427155510-04e1c67f3eed/go.mod h1:AO+KV7pmYJ2xI1GKa6xh9I1KJYvVoWYvofxG9h33xms=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/types/config.go
+++ b/types/config.go
@@ -41,6 +41,7 @@ type PocketConfig struct {
 	CtxCacheSize             int    `json:"ctx_cache_size"`
 	ABCILogging              bool   `json:"abci_logging"`
 	RelayErrors              bool   `json:"show_relay_errors"`
+	DisableTxEvents          bool   `json:"disable_tx_events"`
 }
 
 type Config struct {
@@ -54,43 +55,45 @@ type AuthToken struct {
 }
 
 const (
-	DefaultDDName                     = ".pocket"
-	DefaultKeybaseName                = "pocket-keybase"
-	DefaultPVKName                    = "priv_val_key.json"
-	DefaultPVSName                    = "priv_val_state.json"
-	DefaultNKName                     = "node_key.json"
-	DefaultChainsName                 = "chains.json"
-	DefaultGenesisName                = "genesis.json"
-	DefaultRPCPort                    = "8081"
-	DefaultSessionDBName              = "session"
-	DefaultEvidenceDBName             = "pocket_evidence"
-	DefaultTMURI                      = "tcp://localhost:26657"
-	DefaultMaxSessionCacheEntries     = 500
-	DefaultMaxEvidenceCacheEntries    = 500
-	DefaultListenAddr                 = "tcp://0.0.0.0:"
-	DefaultClientBlockSyncAllowance   = 10
-	DefaultJSONSortRelayResponses     = true
-	DefaultTxIndexer                  = "kv"
-	DefaultTxIndexTags                = "tx.hash,tx.height,message.sender,transfer.recipient"
-	ConfigDirName                     = "config"
-	ConfigFileName                    = "config.json"
-	ApplicationDBName                 = "application"
-	PlaceholderHash                   = "0001"
-	PlaceholderURL                    = "http://127.0.0.1:8081"
-	PlaceholderServiceURL             = PlaceholderURL
-	DefaultRemoteCLIURL               = "http://localhost:8081"
-	DefaultUserAgent                  = ""
-	DefaultValidatorCacheSize         = 100
-	DefaultApplicationCacheSize       = DefaultValidatorCacheSize
-	DefaultPocketPrometheusListenAddr = "8083"
-	DefaultPrometheusMaxOpenFile      = 3
-	DefaultRPCTimeout                 = 3000
-	DefaultMaxClaimProofRetryAge      = 32
-	DefaultProofPrevalidation         = false
-	DefaultCtxCacheSize               = 20
-	DefaultABCILogging                = false
-	DefaultRelayErrors                = true
-	AuthFileName                      = "auth.json"
+	DefaultDDName                      = ".pocket"
+	DefaultKeybaseName                 = "pocket-keybase"
+	DefaultPVKName                     = "priv_val_key.json"
+	DefaultPVSName                     = "priv_val_state.json"
+	DefaultNKName                      = "node_key.json"
+	DefaultChainsName                  = "chains.json"
+	DefaultGenesisName                 = "genesis.json"
+	DefaultRPCPort                     = "8081"
+	DefaultSessionDBName               = "session"
+	DefaultEvidenceDBName              = "pocket_evidence"
+	DefaultTMURI                       = "tcp://localhost:26657"
+	DefaultMaxSessionCacheEntries      = 500
+	DefaultMaxEvidenceCacheEntries     = 500
+	DefaultListenAddr                  = "tcp://0.0.0.0:"
+	DefaultClientBlockSyncAllowance    = 10
+	DefaultJSONSortRelayResponses      = true
+	DefaultTxIndexer                   = "kv"
+	DefaultRPCDisableTransactionEvents = true
+	DefaultTxIndexTags                 = "tx.hash,tx.height,message.sender,transfer.recipient"
+	ConfigDirName                      = "config"
+	ConfigFileName                     = "config.json"
+	ApplicationDBName                  = "application"
+	TransactionIndexerDBName           = "txindexer"
+	PlaceholderHash                    = "0001"
+	PlaceholderURL                     = "http://127.0.0.1:8081"
+	PlaceholderServiceURL              = PlaceholderURL
+	DefaultRemoteCLIURL                = "http://localhost:8081"
+	DefaultUserAgent                   = ""
+	DefaultValidatorCacheSize          = 100
+	DefaultApplicationCacheSize        = DefaultValidatorCacheSize
+	DefaultPocketPrometheusListenAddr  = "8083"
+	DefaultPrometheusMaxOpenFile       = 3
+	DefaultRPCTimeout                  = 3000
+	DefaultMaxClaimProofRetryAge       = 32
+	DefaultProofPrevalidation          = false
+	DefaultCtxCacheSize                = 20
+	DefaultABCILogging                 = false
+	DefaultRelayErrors                 = true
+	AuthFileName                       = "auth.json"
 )
 
 func DefaultConfig(dataDir string) Config {
@@ -121,6 +124,7 @@ func DefaultConfig(dataDir string) Config {
 			CtxCacheSize:             DefaultCtxCacheSize,
 			ABCILogging:              DefaultABCILogging,
 			RelayErrors:              DefaultRelayErrors,
+			DisableTxEvents:          DefaultRPCDisableTransactionEvents,
 		},
 	}
 	c.TendermintConfig.LevelDBOptions = config.DefaultLevelDBOpts()

--- a/types/indexer.go
+++ b/types/indexer.go
@@ -1,0 +1,292 @@
+package types
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"github.com/jordanorelli/lexnum"
+	"github.com/pkg/errors"
+	"github.com/tendermint/tendermint/libs/pubsub/query"
+	"github.com/tendermint/tendermint/state/txindex"
+	"github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+	"math"
+)
+
+var (
+	_ txindex.TxIndexer = &TransactionIndexer{}
+	e                   = lexnum.NewEncoder('=', '-')
+)
+
+const (
+	TxHeightKey         = "tx.height"
+	TxSignerKey         = "tx.signer"
+	TxRecipientKey      = "tx.recipient"
+	TxHashKey           = "tx.hash"
+	SortAscending       = "asc"
+	SortDescending      = "desc"
+	AuthCodespace       = "auth"
+	sep                 = "/"
+	maxPerPage          = 1000
+	AnteHandlerMaxError = 10
+)
+
+type TransactionIndexer struct {
+	store dbm.DB
+}
+
+func NewTransactionIndexer(store dbm.DB) *TransactionIndexer {
+	return &TransactionIndexer{store: store}
+}
+
+func (t *TransactionIndexer) AddBatch(b *txindex.Batch) error {
+	storeBatch := t.store.NewBatch()
+	defer storeBatch.Close()
+
+	for _, result := range b.Ops { // iterate through all the transaction results
+		if result.Result.Codespace == AuthCodespace && result.Result.Code < AnteHandlerMaxError {
+			continue // don't index any ante handler level errors
+		}
+		hash := result.Tx.Hash()
+
+		// index tx by sender
+		if result.Result.Signer != nil {
+			storeBatch.Set(keyForSigner(result), hash)
+		}
+
+		// index tx by height
+		storeBatch.Set(keyForHeight(result), hash)
+
+		// index tx by hash
+		rawBytes, err := cdc.MarshalBinaryBare(result, 0) // TODO make protobuf compatible
+		if err != nil {
+			return err
+		}
+		storeBatch.Set(hash, rawBytes)
+	}
+
+	return storeBatch.WriteSync()
+}
+
+func (t *TransactionIndexer) Index(result *types.TxResult) error {
+	storeBatch := t.store.NewBatch()
+	defer storeBatch.Close()
+	if result.Result.Codespace == AuthCodespace && result.Result.Code < AnteHandlerMaxError {
+		return nil // no indexing for ante handler level errors
+	}
+	hash := result.Tx.Hash()
+	// index tx by sender
+	if result.Result.Signer != nil {
+		storeBatch.Set(keyForSigner(result), hash)
+	}
+
+	// index tx by recipient
+	if result.Result.Recipient != nil {
+		storeBatch.Set(keyForRecipient(result), hash)
+	}
+
+	// index tx by height
+	storeBatch.Set(keyForHeight(result), hash)
+
+	// index tx by hash
+	rawBytes, err := cdc.MarshalBinaryBare(result, 0) // TODO make protobuf compatible
+	if err != nil {
+		return err
+	}
+	storeBatch.Set(hash, rawBytes)
+
+	return storeBatch.WriteSync()
+}
+
+func (t *TransactionIndexer) Get(hash []byte) (*types.TxResult, error) {
+	if len(hash) == 0 {
+		return nil, txindex.ErrorEmptyHash
+	}
+
+	rawBytes, _ := t.store.Get(hash)
+	if rawBytes == nil {
+		return nil, nil
+	}
+
+	txResult := new(types.TxResult)
+	err := cdc.UnmarshalBinaryBare(rawBytes, &txResult, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error reading TxResult: %v", err)
+	}
+
+	return txResult, nil
+}
+
+// NOTE: Only supports op.Equal for hash, height, signer, or recipient
+func (t *TransactionIndexer) Search(ctx context.Context, q *query.Query) ([]*types.TxResult, error) {
+	// get a list of conditions (like "tx.height > 5")
+	condition, err := q.Condition()
+	if err != nil {
+		return nil, errors.Wrap(err, "error during parsing condition from query")
+	}
+
+	if q.Pagination.Size > maxPerPage {
+		q.Pagination.Size = maxPerPage
+	}
+
+	if condition.Op != query.OpEqual {
+		return nil, fmt.Errorf("transaction indexer only supports op.Equal not %v", condition.Op)
+	}
+
+	switch condition.CompositeKey {
+	case TxHeightKey:
+		return t.heightQuery(condition, q.Pagination)
+	case TxSignerKey:
+		return t.signerQuery(condition, q.Pagination)
+	case TxRecipientKey:
+		return t.recipientQuery(condition, q.Pagination)
+	case TxHashKey:
+		return t.hashQuery(condition)
+	default:
+		return nil, fmt.Errorf("Condition.CompositeKey: %v not supported on this indexer", condition.CompositeKey)
+	}
+}
+
+func (t *TransactionIndexer) DeleteFromHeight(ctx context.Context, height int64) error {
+	startKey := []byte(fmt.Sprintf("%s/%s",
+		TxHeightKey,
+		e.EncodeInt(int(height)),
+	))
+	endKey := []byte(fmt.Sprintf("%s/%s",
+		TxHeightKey,
+		e.EncodeInt(math.MaxInt64),
+	))
+	it, err := t.store.ReverseIterator(startKey, endKey)
+	if err != nil {
+		return errors.Wrap(err, "error creating the reverse iterator for deleteFromHeight")
+	}
+	defer it.Close()
+	b := t.store.NewBatch()
+	defer b.Close()
+	for ; it.Valid(); it.Next() {
+		b.Delete(it.Value())
+	}
+	return b.WriteSync()
+}
+
+func (t *TransactionIndexer) hashQuery(condition query.Condition) (res []*types.TxResult, err error) {
+	hash, err := hex.DecodeString(condition.Operand.(string))
+	if err != nil {
+		return nil, errors.Wrap(err, "error during searching for a hash in the query")
+	}
+	result, err := t.Get(hash)
+	return []*types.TxResult{result}, err
+}
+
+func (t *TransactionIndexer) heightQuery(condition query.Condition, pagination *query.Page) (res []*types.TxResult, err error) {
+	height, ok := condition.Operand.(int64)
+	if !ok {
+		return nil, errors.New("error during searching for a height in the query, c.Operand not type int64")
+	}
+	return t.getByPrefix(prefixKeyForHeight(height), pagination)
+}
+
+func (t *TransactionIndexer) signerQuery(condition query.Condition, pagination *query.Page) (res []*types.TxResult, err error) {
+	signer, err := hex.DecodeString(condition.Operand.(string))
+	if err != nil {
+		return nil, errors.Wrap(err, "error during searching for a address in the query")
+	}
+	return t.getByPrefix(prefixKeyForSigner(signer), pagination)
+}
+
+func (t *TransactionIndexer) recipientQuery(condition query.Condition, pagination *query.Page) (res []*types.TxResult, err error) {
+	recipient, err := hex.DecodeString(condition.Operand.(string))
+	if err != nil {
+		return nil, errors.Wrap(err, "error during searching for a address in the query")
+	}
+	return t.getByPrefix(prefixKeyForRecipient(recipient), pagination)
+}
+
+func (t *TransactionIndexer) getByPrefix(prefix []byte, pagination *query.Page) (res []*types.TxResult, err error) {
+	it, err := PrefixIterator(t.store, prefix, pagination.Sort)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating prefix iterator")
+	}
+	defer it.Close()
+	for i, skipCount := 0, 0; it.Valid() && i < pagination.Size; it.Next() {
+		if skipCount < pagination.Skip {
+			skipCount++
+			continue
+		}
+		val, err := t.Get(it.Value())
+		if err != nil {
+			return nil, errors.Wrap(err, "error during query iteration get()")
+		}
+		res = append(res, val)
+		i++
+	}
+	return
+}
+
+func keyForHeight(result *types.TxResult) []byte {
+	return []byte(fmt.Sprintf("%s/%s/%s",
+		TxHeightKey,
+		e.EncodeInt(int(result.Height)),
+		e.EncodeInt(int(result.Index)),
+	))
+}
+
+func prefixKeyForHeight(height int64) []byte {
+	return []byte(fmt.Sprintf("%s/%s/",
+		TxHeightKey,
+		e.EncodeInt(int(height)),
+	))
+}
+
+func keyForSigner(result *types.TxResult) []byte {
+	return []byte(fmt.Sprintf("%s/%s/%s/%s",
+		TxSignerKey,
+		Address(result.Result.Signer),
+		e.EncodeInt(int(result.Height)),
+		e.EncodeInt(int(result.Index)),
+	))
+}
+
+func prefixKeyForSigner(signer Address) []byte {
+	return []byte(fmt.Sprintf("%s/%s/%s",
+		TxSignerKey,
+		signer,
+		e.EncodeInt(0),
+	))
+}
+
+func keyForRecipient(result *types.TxResult) []byte {
+	return []byte(fmt.Sprintf("%s/%s/%s/%s",
+		TxRecipientKey,
+		Address(result.Result.Recipient),
+		e.EncodeInt(int(result.Height)),
+		e.EncodeInt(int(result.Index)),
+	))
+}
+
+func prefixKeyForRecipient(recipient Address) []byte {
+	return []byte(fmt.Sprintf("%s/%s/%s",
+		TxRecipientKey,
+		recipient,
+		e.EncodeInt(0),
+	))
+}
+
+// contract: caller must close iterator
+func PrefixIterator(db dbm.DB, prefix []byte, order string) (dbm.Iterator, error) {
+	switch order {
+	case SortAscending:
+		return db.ReverseIterator(prefix, endKey(prefix))
+	case SortDescending:
+		return db.Iterator(prefix, endKey(prefix))
+	default:
+		return nil, fmt.Errorf("sorting order: %v not supported", order)
+	}
+}
+
+func endKey(prefix []byte) []byte {
+	bz := bytes.Split(prefix, []byte(sep))
+	bz = append(bz[:len(bz)-1], []byte(e.EncodeInt(math.MaxInt64)))
+	return bytes.Join(bz[:], []byte(sep))
+}

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -23,6 +23,9 @@ type Msg interface {
 	// CONTRACT: Returns addrs in some deterministic order.
 	GetSigner() Address
 
+	// Returns the recipient of the tx, if no recipient returns nil
+	GetRecipient() Address
+
 	// Returns an BigInt for the ProtoMsg
 	GetFee() BigInt
 }
@@ -51,6 +54,9 @@ type ProtoMsg interface {
 	// CONTRACT: All signatures must be present to be valid.
 	// CONTRACT: Returns addrs in some deterministic order.
 	GetSigner() Address
+
+	// Returns the recipient of the tx, if no recipient returns nil
+	GetRecipient() Address
 
 	// Returns an BigInt for the ProtoMsg
 	GetFee() BigInt

--- a/x/apps/types/msg.go
+++ b/x/apps/types/msg.go
@@ -33,6 +33,10 @@ func (msg MsgStake) GetSigner() sdk.Address {
 	return sdk.Address(msg.PubKey.Address())
 }
 
+func (msg MsgStake) GetRecipient() sdk.Address {
+	return nil
+}
+
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgStake) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
@@ -144,6 +148,10 @@ func (msg MsgBeginUnstake) GetSigner() sdk.Address {
 	return msg.Address
 }
 
+func (msg MsgBeginUnstake) GetRecipient() sdk.Address {
+	return nil
+}
+
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgBeginUnstake) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
@@ -184,6 +192,10 @@ func (msg MsgUnjail) GetFee() sdk.BigInt {
 // GetSigners return address(es) that must sign over msg.GetSignBytes()
 func (msg MsgUnjail) GetSigner() sdk.Address {
 	return msg.AppAddr
+}
+
+func (msg MsgUnjail) GetRecipient() sdk.Address {
+	return nil
 }
 
 // GetSignBytes returns the message bytes to sign over.

--- a/x/gov/types/msg.go
+++ b/x/gov/types/msg.go
@@ -8,6 +8,7 @@ import (
 var (
 	_ sdk.ProtoMsg = &MsgChangeParam{}
 	_ sdk.ProtoMsg = &MsgDAOTransfer{}
+	_ sdk.ProtoMsg = &MsgUpgrade{}
 )
 
 const (
@@ -38,6 +39,11 @@ func (msg MsgChangeParam) GetFee() sdk.BigInt {
 // GetSigner return address(es) that must sign over msg.GetSignBytes()
 func (msg MsgChangeParam) GetSigner() sdk.Address {
 	return msg.FromAddress
+}
+
+// GetSigner return address(es) that must sign over msg.GetSignBytes()
+func (msg MsgChangeParam) GetRecipient() sdk.Address {
+	return nil
 }
 
 // GetSignBytes returns the message bytes to sign over.
@@ -86,6 +92,11 @@ func (msg MsgDAOTransfer) GetSigner() sdk.Address {
 	return msg.FromAddress
 }
 
+// GetSigner return address(es) that must sign over msg.GetSignBytes()
+func (msg MsgDAOTransfer) GetRecipient() sdk.Address {
+	return nil
+}
+
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgDAOTransfer) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
@@ -132,6 +143,11 @@ func (msg MsgUpgrade) GetFee() sdk.BigInt {
 // GetSigner return address(es) that must sign over msg.GetSignBytes()
 func (msg MsgUpgrade) GetSigner() sdk.Address {
 	return msg.Address
+}
+
+// GetSigner return address(es) that must sign over msg.GetSignBytes()
+func (msg MsgUpgrade) GetRecipient() sdk.Address {
+	return nil
 }
 
 // GetSignBytes returns the message bytes to sign over.

--- a/x/nodes/types/msg.go
+++ b/x/nodes/types/msg.go
@@ -29,6 +29,10 @@ func (msg MsgBeginUnstake) GetSigner() sdk.Address {
 	return msg.Address
 }
 
+func (msg MsgBeginUnstake) GetRecipient() sdk.Address {
+	return nil
+}
+
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgBeginUnstake) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
@@ -61,6 +65,10 @@ func (msg MsgUnjail) GetSigner() sdk.Address {
 	return msg.ValidatorAddr
 }
 
+func (msg MsgUnjail) GetRecipient() sdk.Address {
+	return nil
+}
+
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgUnjail) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
@@ -91,6 +99,10 @@ func (msg MsgUnjail) GetFee() sdk.BigInt {
 // GetSigners return address(es) that must sign over msg.GetSignBytes()
 func (msg MsgSend) GetSigner() sdk.Address {
 	return msg.FromAddress
+}
+
+func (msg MsgSend) GetRecipient() sdk.Address {
+	return msg.ToAddress
 }
 
 // GetSignBytes returns the message bytes to sign over.
@@ -179,6 +191,10 @@ func (msg *MsgStake) Unmarshal(data []byte) error {
 
 func (msg MsgStake) GetSigner() sdk.Address {
 	return sdk.Address(msg.PublicKey.Address())
+}
+
+func (msg MsgStake) GetRecipient() sdk.Address {
+	return nil
 }
 
 // GetSignBytes returns the message bytes to sign over.

--- a/x/pocketcore/types/msgs.go
+++ b/x/pocketcore/types/msgs.go
@@ -82,6 +82,11 @@ func (msg MsgClaim) GetSigner() sdk.Address {
 	return msg.FromAddress
 }
 
+// "GetSigners" - Defines whose signature is required
+func (msg MsgClaim) GetRecipient() sdk.Address {
+	return nil
+}
+
 // "IsEmpty" - Returns true if the EvidenceType == 0, this should only happen on initialization and MsgClaim{} calls
 func (msg MsgClaim) IsEmpty() bool {
 	return msg.EvidenceType == 0
@@ -191,6 +196,11 @@ func (msg MsgProof) GetSignBytes() []byte {
 // GetSigners defines whose signature is required
 func (msg MsgProof) GetSigner() sdk.Address {
 	return msg.Leaf.GetSigner()
+}
+
+// "GetSigners" - Defines whose signature is required
+func (msg MsgProof) GetRecipient() sdk.Address {
+	return nil
 }
 
 func (msg MsgProof) GetLeaf() Proof {


### PR DESCRIPTION
closes #1191 
closes #1187
closes #1302
closes #1301 
closes #1231

**Custom Indexer**
Since LevelDB comparators order lexicongraphically, the implementation uses ELEN to encode numbers to ensure alphanumerical
ordering at insertion time. https://www.zanopha.com/docs/elen.pdf
Since the keys are sorted alphanumerically from the start, we don't have to:
    - Load all results to memory 
    - Paginate and sort transactions after
This indexer inserts in sorted order so it can paginate and return based on the db iterator resulting in a significant 
reduction in resource consumption

The custom pocket core transaction indexer also reduces the scope of the Search() functionality to optimize strictly for 
the following use cases:
    - BlockTxs (Get transactions at a certain height)
    - AccountTxs (Get transactions for a certain account (sent and received))
    
The custom pocket core transaction indexer also injects the message_type into the struct to provide an easier method of 
parsing the transactions. `json:"message_type"`