### PR TITLE
Docs: fix broken link

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@ The Pocket Core application will allow anyone to spin up a Pocket Network full n
 
 [Pocket Core CLI Spec](specs/cli/)
 
-[Pocket Core RPC Spec](specs/rpc-spec.md)
+[Pocket Core RPC Spec](specs/rpc-spec.yaml)
 
 [Pocket Core Architecture](specs/architecture.md)
 


### PR DESCRIPTION
The RPC spec's not a `md` file anymore, but a `yaml` file, so the link to it was broken.