### PR TITLE
Fix for the issue triggered by needing to respond to a client with an error and the dispatch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	AppVersion = "BETA-0.6.3.9"
+	AppVersion = "BETA-0.6.3.10"
 )
 
 // NewPocketCoreApp is a constructor function for PocketCoreApp

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -299,6 +299,7 @@ func (rs *Store) LoadLazyVersion(ver int64) (*types.Store, error) {
 		lazyLoading:  rs.lazyLoading,
 		traceWriter:  rs.traceWriter,
 		traceContext: newTraceCtx,
+		Cache:        rs.Cache,
 	})
 	return &s, nil
 }


### PR DESCRIPTION
This fix addresses an issue in a relatively common path of the code and the way it interacts with the cache: when a relay had an error, and merited a response with the dispatch, the iavl store version was being instantiated with no cache, triggering a panic. This path now ensures the cache from the store is preserved.