### PR TITLE
Fix RPC link in docs.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@ The Pocket Core application will allow anyone to spin up a Pocket Network full n
 
 [Pocket Core CLI Spec](specs/cli/)
 
-[Pocket Core RPC Spec](specs/rpc-spec.yaml)
+[Pocket Core RPC Spec](specs/rpc-spec.md)
 
 [Pocket Core Architecture](specs/architecture.md)
 

--- a/doc/specs/cli/rpc-spec.md
+++ b/doc/specs/cli/rpc-spec.md
@@ -1,3 +1,0 @@
-# RPC
-
-View the RPC spec [here](https://github.com/pokt-network/pocket-core/blob/staging/doc/specs/rpc-spec.yaml).

--- a/doc/specs/rpc-spec.md
+++ b/doc/specs/rpc-spec.md
@@ -1,0 +1,3 @@
+# RPC
+
+View the raw RPC spec [here](https://github.com/pokt-network/pocket-core/blob/staging/doc/specs/rpc-spec.yaml) or use Swagger UI [here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/pokt-network/pocket-core/staging/doc/specs/rpc-spec.yaml).


### PR DESCRIPTION
- Fix the link to the RPC markdown file.
- Add link to Swagger UI editor.