### PR TITLE
Wrong parameter name in rpc-spec.yaml

### DIFF
--- a/doc/specs/rpc-spec.yaml
+++ b/doc/specs/rpc-spec.yaml
@@ -789,7 +789,7 @@ paths:
                 staking_status: 0x02
                 page: 1
                 per_page: 100
-                chain: ""
+                blockchain: ""
                 jailed_status: 1
               height: 2
         required: true


### PR DESCRIPTION
The commit 4bf060fd870b707fd3eed18a169cbdcfe30a9c55 forgot to update rpc-spec.yaml.