### PR TITLE
Use the current height when /query/block is invoked without height

### DIFF
--- a/app/cmd/rpc/query.go
+++ b/app/cmd/rpc/query.go
@@ -82,6 +82,9 @@ func Block(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		WriteErrorResponse(w, 400, err.Error())
 		return
 	}
+	if params.Height == 0 {
+		params.Height = app.PCA.BaseApp.LastBlockHeight()
+	}
 	res, err := app.PCA.QueryBlock(&params.Height)
 	if err != nil {
 		WriteErrorResponse(w, 400, err.Error())


### PR DESCRIPTION
Fix for #1432