### PR TITLE
Unconfirmed txs

### DIFF
--- a/app/cmd/rpc/server.go
+++ b/app/cmd/rpc/server.go
@@ -122,6 +122,8 @@ func GetRoutes() Routes {
 		Route{Name: "QueryUpgrade", Method: "POST", Path: "/v1/query/upgrade", HandlerFunc: Upgrade},
 		Route{Name: "QuerySigningInfo", Method: "POST", Path: "/v1/query/signinginfo", HandlerFunc: SigningInfo},
 		Route{Name: "QueryChains", Method: "POST", Path: "/v1/private/chains", HandlerFunc: Chains},
+		Route{Name: "QueryUnconfirmedTxs", Method: "POST", Path: "/v1/query/unconfirmedtxs", HandlerFunc: UnconfirmedTxs},
+		Route{Name: "QueryUnconfirmedTx", Method: "POST", Path: "/v1/query/unconfirmedtx", HandlerFunc: UnconfirmedTx},
 	}
 	return routes
 }

--- a/app/query.go
+++ b/app/query.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 
 	sdk "github.com/pokt-network/pocket-core/types"
 	appsTypes "github.com/pokt-network/pocket-core/x/apps/types"
@@ -114,6 +115,60 @@ func (app PocketCoreApp) QueryAllBlockTxs(height int64, page, perPage int) (res 
 		}
 	}
 	return
+}
+
+func (app PocketCoreApp) QueryUnconfirmedTxs(page, perPage int) (res *core_types.ResultUnconfirmedTxs, err error) {
+	res = &core_types.ResultUnconfirmedTxs{
+		Count: 0,
+		Total: 0,
+		Txs:   make([]tmtypes.Tx, 0),
+	}
+	tmClient := app.GetClient()
+	defer func() { _ = tmClient.Stop() }()
+	page, perPage = checkPagination(page, perPage)
+
+	unconfirmedTxsResult, err := tmClient.UnconfirmedTxs(app.BaseApp.TMNode().Mempool().Size())
+	if err != nil {
+		return nil, err
+	}
+
+	skip := (page - 1) * perPage
+	res.Total = unconfirmedTxsResult.Total
+
+	for i, t := range unconfirmedTxsResult.Txs {
+		if i < skip {
+			continue
+		}
+		res.Txs = append(res.Txs, t)
+		if len(res.Txs) >= perPage {
+			break
+		}
+	}
+
+	res.Count = len(res.Txs)
+	return
+}
+
+func (app PocketCoreApp) QueryUnconfirmedTx(hash string) (res tmtypes.Tx, err error) {
+	tmClient := app.GetClient()
+	defer func() { _ = tmClient.Stop() }()
+
+	hash = strings.ToLower(hash)
+
+	unconfirmedTxsResult, err := tmClient.UnconfirmedTxs(app.BaseApp.TMNode().Mempool().Size())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range unconfirmedTxsResult.Txs {
+		txHash := strings.ToLower(fmt.Sprintf("%x", t.Hash()))
+
+		if txHash == hash {
+			return t, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func (app PocketCoreApp) QueryHeight() (res int64, err error) {

--- a/doc/specs/rpc-spec.yaml
+++ b/doc/specs/rpc-spec.yaml
@@ -652,6 +652,29 @@ paths:
                 $ref: '#/components/schemas/QueryBlockTXsResponse'
         '400':
           description: Failed to retrieve the transaction information
+  /query/unconfirmedtxs:
+    post:
+      tags:
+        - query
+      requestBody:
+        description: Returns all unconfirmed transactions handled by the mempool; Max per_page = 1000".
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryUnconfirmedTXs'
+            example:
+              page: 1
+              per_page: 1000
+        required: true
+      responses:
+        '200':
+          description: Unconfirmed Transaction list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryUnconfirmedTXsResponse'
+        '400':
+          description: Failed to retrieve the unconfirmed transactions information
   /query/height:
     post:
       tags:
@@ -1187,6 +1210,28 @@ paths:
                 $ref: '#/components/schemas/QueryTXResponse'
         '400':
           description: Failed to retrieve the transaction information
+  /query/unconfirmedtx:
+    post:
+      tags:
+        - query
+      requestBody:
+        description: Returns the unconfirmed transaction by the hash
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryUnconfirmedTX'
+            example:
+              hash: '0x197e4d46009879f28f978a90627c7dfeab64b4777afcc24e2b9c3d72b4dada22'
+        required: true
+      responses:
+        '200':
+          description: Unconfirmed Transaction data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryUnconfirmedTXResponse'
+        '400':
+          description: Failed to retrieve the unconfirmed transaction information
   /query/upgrade:
     post:
       tags:
@@ -2001,6 +2046,17 @@ components:
           type: string
         proof:
           $ref: '#/components/schemas/SimpleProof'
+    UnconfirmedTransaction:
+      type: object
+      properties:
+        hash:
+          type: string
+          description: Hash of the transaction
+        message_type:
+          type: string
+          description: Transaction type like the one provide on Transaction tx_result.message_type
+        stdTx:
+          $ref: '#/components/schemas/StdTx'
     QueryAddressHeight:
       type: object
       properties:
@@ -2385,6 +2441,16 @@ components:
         per_page:
           type: integer
           format: int64
+    QueryUnconfirmedTX:
+      type: object
+      properties:
+        hash:
+          type: string
+    QueryUnconfirmedTXResponse:
+      type: object
+      properties:
+        transaction:
+          $ref: '#/components/schemas/UnconfirmedTransaction'
     QueryPaginatedHeightAndAddrParams:
       type: object
       properties:
@@ -2449,6 +2515,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Transaction'
+        page_count:
+          type: integer
+        total_txs:
+          type: integer
+    QueryUnconfirmedTXs:
+      type: object
+      properties:
+        page:
+          type: integer
+        per_page:
+          type: integer
+    QueryUnconfirmedTXsResponse:
+      type: object
+      properties:
+        txs:
+          type: array
+          items:
+            $ref: '#/components/schemas/UnconfirmedTransaction'
         page_count:
           type: integer
         total_txs:


### PR DESCRIPTION
- Added /v1/query/unconfirmedtxs
    - returns unconfirmed transactions following blocktxs params (page & per_page) and blocktxs response
    - txs are decoded following same blocktxs format (hash + stdTx)
- Added /v1/query/unconfirmedtx
    - look by hash on tendermint unconfirmed_txs and return it following blocktxs params and response
- Added Test for Query and RPC
- Added RPC Spec about new endpoints