### PR TITLE
Fix for Syncing from 0 on testnet with beta

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	AppVersion = "BETA-0.9.0"
+	AppVersion = "RC-0.9.0"
 )
 
 // NewPocketCoreApp is a constructor function for PocketCoreApp

--- a/app/tx_test.go
+++ b/app/tx_test.go
@@ -942,7 +942,7 @@ func TestChangeParamsMaxBlocksizeBeforeActivationHeight(t *testing.T) {
 			<-evtChan // Wait for block
 			//Before Activation of the parameter ACL do not exist and the value and parameter should be 0 or nil
 			firstquery, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pocketcore/BlockByteSize")
-			assert.Equal(t, "0", firstquery.Value)
+			assert.Equal(t, "", firstquery.Value)
 			memCli, stopCli, evtChan := subscribeTo(t, tmTypes.EventTx)
 			//Tx wont modify anything as ACL is not configured (Txresult should be gov code 5)
 			tx, err := gov.ChangeParamsTx(memCodec(), memCli, kb, cb.GetAddress(), "pocketcore/BlockByteSize", 9000000, "test", 10000, false)
@@ -987,18 +987,18 @@ func TestChangepip22ParamsBeforeActivationHeight(t *testing.T) {
 			_, _, evtChan := subscribeTo(t, tmTypes.EventNewBlock)
 			<-evtChan // Wait for block
 			//Before Activation of the parameter ACL do not exist and the value and parameter should be 0 or nil
-			firstquery, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pos/ServicerStakeFloorMultiplier")
-			assert.Equal(t, "0", firstquery.Value)
+			firstquery, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pos/ServicerStakeWeightMultiplier")
+			assert.Equal(t, "", firstquery.Value)
 			memCli, stopCli, evtChan := subscribeTo(t, tmTypes.EventTx)
 			//Tx wont modify anything as ACL is not configured (Txresult should be gov code 5)
-			tx, err := gov.ChangeParamsTx(memCodec(), memCli, kb, cb.GetAddress(), "pos/ServicerStakeFloorMultiplier", 150000, "test", 10000, false)
+			tx, err := gov.ChangeParamsTx(memCodec(), memCli, kb, cb.GetAddress(), "pos/ServicerStakeWeightMultiplier", 1, "test", 10000, false)
 			assert.Nil(t, err)
 			assert.NotNil(t, tx)
 			select {
 			case _ = <-evtChan:
 				//fmt.Println(res)
 				assert.Nil(t, err)
-				o, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pos/ServicerStakeFloorMultiplier")
+				o, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pos/ServicerStakeWeightMultiplier")
 				//value should be equal to the first query of the param
 				assert.Equal(t, firstquery.Value, o.Value)
 				cleanup()
@@ -1020,7 +1020,7 @@ func TestChangeParamsMaxBlocksizeAfterActivationHeight(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			codec.TestMode = -2
-			codec.UpgradeFeatureMap[codec.BlockSizeModifyKey] = tc.upgrades.codecUpgrade.height
+			codec.UpgradeFeatureMap[codec.BlockSizeModifyKey] = tc.upgrades.codecUpgrade.height + 1
 			if tc.upgrades != nil { // NOTE: Use to perform neccesary upgrades for test
 				codec.UpgradeHeight = tc.upgrades.codecUpgrade.height
 				_ = memCodecMod(tc.upgrades.codecUpgrade.upgradeMod)
@@ -1034,6 +1034,7 @@ func TestChangeParamsMaxBlocksizeAfterActivationHeight(t *testing.T) {
 			assert.Nil(t, err)
 			_, _, evtChan := subscribeTo(t, tmTypes.EventNewBlock)
 			<-evtChan // Wait for block
+			<-evtChan // Wait for another block
 			//After Activation of the parameter ACL should be created(allowing modifying the value) and parameter should have default value of 4000000
 			o, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pocketcore/BlockByteSize")
 			assert.Equal(t, "4000000", o.Value)
@@ -1065,7 +1066,7 @@ func TestChangeParamspip22afterActivationHeight(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			codec.TestMode = -3
-			codec.UpgradeFeatureMap[codec.RSCALKey] = tc.upgrades.codecUpgrade.height
+			codec.UpgradeFeatureMap[codec.RSCALKey] = tc.upgrades.codecUpgrade.height + 1
 			if tc.upgrades != nil { // NOTE: Use to perform neccesary upgrades for test
 				codec.UpgradeHeight = tc.upgrades.codecUpgrade.height
 				_ = memCodecMod(tc.upgrades.codecUpgrade.upgradeMod)
@@ -1079,6 +1080,7 @@ func TestChangeParamspip22afterActivationHeight(t *testing.T) {
 			assert.Nil(t, err)
 			_, _, evtChan := subscribeTo(t, tmTypes.EventNewBlock)
 			<-evtChan // Wait for block
+			<-evtChan // Wait for another block
 			//After Activation of the parameter ACL should be created(allowing modifying the value) and parameter should have default value of 4000000
 			o, _ := PCA.QueryParam(PCA.LastBlockHeight(), "pos/ServicerStakeFloorMultiplier")
 			assert.Equal(t, "15000000000", o.Value)

--- a/doc/releases/changelog.md
+++ b/doc/releases/changelog.md
@@ -4,12 +4,13 @@
 - Mempool Refinements :
   - Tx max life in mempool is 2 blocks, after that txs are considered stale and evicted from the mempool
   so they won't get to the block.
-  - add validation for edge case on cache equals to 0.
-- backport tendermint #6068 (terminate broadcastEvidenceRoutine when peer is stopped)
+  - Add validation for edge case on cache equals to 0.
+- Backport tendermint #6068 (terminate broadcastEvidenceRoutine when peer is stopped)
 - Add new rpc endpoint /query/accounts.
 - New config.json option to enable/disable authToken generation on start (auth.json).
 - Implementation of PIP22 (Stake Weighted Servicer Rewards)[RSCAL][VEDIT].
 - Customizable Max Block Size bytes and new tendermint evidence age.[BLOCK].
+- Fix sync from scratch issue related to handling of new additional parameters.
 
 ## RC-0.8.3
 

--- a/types/utils.go
+++ b/types/utils.go
@@ -141,3 +141,12 @@ func TimeTrack(start time.Time) {
 		log.Println(fmt.Sprintf("%s took %s", name, elapsed))
 	}
 }
+
+func ContainsString(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/x/nodes/handler.go
+++ b/x/nodes/handler.go
@@ -51,6 +51,14 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 
 func handleStake(ctx sdk.Ctx, msg types.MsgStake, k keeper.Keeper, signer crypto.PublicKey) sdk.Result {
 	defer sdk.TimeTrack(time.Now())
+
+	if k.Cdc.IsAfterNonCustodialUpgrade(ctx.BlockHeight()) {
+		err := msg.CheckServiceUrlLength(msg.ServiceUrl)
+		if err != nil {
+			return err.Result()
+		}
+	}
+
 	pk := msg.PublicKey
 	addr := pk.Address()
 	// create validator object using the message fields

--- a/x/nodes/keeper/reward_test.go
+++ b/x/nodes/keeper/reward_test.go
@@ -205,8 +205,9 @@ func TestKeeper_rewardFromRelaysPIP22NoEXP(t *testing.T) {
 		validator4 types.Validator
 	}
 
-	codec.UpgradeFeatureMap[codec.RSCALKey] = -1
+	codec.UpgradeFeatureMap[codec.RSCALKey] = 3
 	context, _, keeper := createTestInput(t, true)
+	context = context.WithBlockHeight(3)
 	p := keeper.GetParams(context)
 	p.ServicerStakeFloorMultiplier = types.DefaultServicerStakeFloorMultiplier
 	p.ServicerStakeWeightMultiplier = types.DefaultServicerStakeWeightMultiplier
@@ -282,8 +283,9 @@ func TestKeeper_checkPIP22CheckCeiling(t *testing.T) {
 		validator2 types.Validator
 	}
 
-	codec.UpgradeFeatureMap[codec.RSCALKey] = -1
+	codec.UpgradeFeatureMap[codec.RSCALKey] = 3
 	context, _, keeper := createTestInput(t, true)
+	context = context.WithBlockHeight(3)
 	p := keeper.GetParams(context)
 	p.ServicerStakeFloorMultiplier = types.DefaultServicerStakeFloorMultiplier
 	p.ServicerStakeWeightMultiplier = types.DefaultServicerStakeWeightMultiplier
@@ -343,8 +345,9 @@ func TestKeeper_rewardFromRelaysPIP22EXP(t *testing.T) {
 		validator4 types.Validator
 	}
 
-	codec.UpgradeFeatureMap[codec.RSCALKey] = -1
+	codec.UpgradeFeatureMap[codec.RSCALKey] = 3
 	context, _, keeper := createTestInput(t, true)
+	context = context.WithBlockHeight(3)
 	p := keeper.GetParams(context)
 	p.ServicerStakeFloorMultiplier = types.DefaultServicerStakeFloorMultiplier
 	p.ServicerStakeWeightMultiplier = types.DefaultServicerStakeWeightMultiplier

--- a/x/nodes/types/msg.go
+++ b/x/nodes/types/msg.go
@@ -276,6 +276,13 @@ func (msg MsgStake) ToProto() MsgProtoStake {
 	}
 }
 
+func (msg MsgStake) CheckServiceUrlLength(url string) sdk.Error {
+	if len(url) > 255 {
+		return ErrInvalidServiceURL(DefaultCodespace, fmt.Errorf("url too long"))
+	}
+	return nil
+}
+
 func (*MsgProtoStake) XXX_MessageName() string {
 	return "x.nodes.MsgProtoStake8"
 }

--- a/x/nodes/types/util.go
+++ b/x/nodes/types/util.go
@@ -41,9 +41,6 @@ func ValidateServiceURL(u string) sdk.Error {
 	if !strings.Contains(u, period) {
 		return ErrInvalidServiceURL(ModuleName, fmt.Errorf("must contain one '.'"))
 	}
-	if len(u) > 255 {
-		return ErrInvalidServiceURL(ModuleName, fmt.Errorf("url too long"))
-	}
 
 	return nil
 }


### PR DESCRIPTION
Also Updating Version to RC.

Updated test to reflect empty value instead of 0 and proper setup.

Brief explanation: Ignoring additional parameters on key heights(genesis/codec change) so apphash is not changed with new parameters inclusion.