### PR TITLE
Consolidate email to share security vulnerabilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ RC (or release candidates) are releases meant for production deployment. Release
 
 #### Starting a disclosure
 
-To start the disclosure process, please send an email containing all evidence, documents and/or links for the vulnerability you are disclosing to `pocket-core-security@pokt.network`. You will receive a response within a 24 hour window outlining next steps.
+To start the disclosure process, please send an email containing all evidence, documents and/or links for the vulnerability you are disclosing to `security@pokt.network`. You will receive a response within a 24 hour window outlining next steps.
 
 #### Public disclosure
 


### PR DESCRIPTION
* security@pokt.network was referenced in [1] 2.5 years ago
* pokt-core-security@pokt.network referenced in [2] 3 months ago
* Both are referenced in this repo

[1] https://www.blog.pokt.network/rc-0-9-0-key-changes
[2] https://www.blog.pokt.network/incentivized-testnet-bug-bounty-program
[3] https://github.com/pokt-network/pocket-core