### PR TITLE
Fix bad and outdated links

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -26,7 +26,7 @@ visit [pokt.network](https://pokt.network).
 
 [Protocol Forum](https://forum.pokt.network/)
 
-[Protocol Wiki](https://docs.pokt.network/home/main-concepts/protocol)
+[Protocol Wiki](https://docs.pokt.network/learn/protocol)
 
 [Community Discord](https://discord.com/invite/KRrqfd3tAK)
 

--- a/doc/guides/quickstart.md
+++ b/doc/guides/quickstart.md
@@ -171,7 +171,7 @@ pocket accounts set-validator <address>
 {% hint style="info" %} Check with `pocket accounts get-validator`
 {% endhint %}
 
-### Set [Relay Chains](https://docs.pokt.network/home/references/supported-blockchains)
+### Set [Relay Chains](https://docs.pokt.network/supported-blockchains/)
 
 {% tabs %} {% tab title="Command" %}
 
@@ -209,7 +209,7 @@ Example:
 pocket start --seeds="64c91701ea98440bc3674fdb9a99311461cdfd6f@node1.mainnet.pokt.network:21656" --mainnet
 ```
 
-[Seeds](https://docs.pokt.network/references/seeds)
+[Seeds](https://docs.pokt.network/node/seeds/)
 
 {% hint style="warning" %} Ensure the node is all the way synced before proceeding to the next step. {% endhint %}
 
@@ -335,7 +335,7 @@ Pocket Core provides a configuration file found in `<datadir>/config/config.json
   laddr
 - **"Seeds"**: The seed nodes used to connect to the network. Must be a comma-separated list in this format:
   &lt;ADDRESS&gt;@ \(Ex: 03b74fa3c68356bb40d58ecc10129479b159a145@seed1.mainnet.pokt.network:20656\).
-  Click [here](https://docs.pokt.network/home/resources/references/seeds) to see a list of seed nodes on Mainnet or
+  Click [here](https://docs.pokt.network/node/seeds/) to see a list of seed nodes on Mainnet or
   Testnet
 - **"PersistentPeers"**: Comma separated list of nodes to keep persistent connections to. Must be a comma separated list
   in this format: &lt;ADDRESS&gt;@ \(Ex: 03b74fa3c68356bb40d58ecc10129479b159a145@seed1.mainnet.pokt.network:20656\)
@@ -449,7 +449,7 @@ Use pocket core flags --mainnet or --testnet to automatically write
 Use the CLI or Manually Edit: `$HOME/.pocket/config/chains.json`
 
 {% hint style="info" %} Relay Chain ID's and docs can be
-found [here](https://docs.pokt.network/home/references/supported-blockchains). {% endhint %}
+found [here](https://docs.pokt.network/supported-blockchains/). {% endhint %}
 
 These are external blockchain nodes such as ethereum, polygon and harmony. You will need to set these up by following their respective documentation. Once they are synced, you can enter the url and credentials into the following file. 
 

--- a/doc/specs/architecture.md
+++ b/doc/specs/architecture.md
@@ -8,7 +8,7 @@ description: >-
 {% hint style="info" %} This document DOES NOT cover the architecture of the Pocket Network protocol. Rather it only
 covers the software-specific implementation details of Pocket Core and for the sake of clarity, orientation, and
 modularity, explicitly avoids covering any details that might duplicate the contents of the Pocket Network protocol
-specification, which can be found [here](https://docs.pokt.network/home/main-concepts/protocol). {% endhint %}
+specification, which can be found [here](https://docs.pokt.network/learn/protocol). {% endhint %}
 
 ## Tendermint and Cosmos SDK
 

--- a/doc/specs/cli/apps.md
+++ b/doc/specs/cli/apps.md
@@ -22,9 +22,9 @@ Arguments:
 
 * `<fromAddr>`: Target Address to stake.
 * `<amount>`: The amount of uPOKT to stake. Must be higher than the current value of the `ApplicationStakeMinimum`
-  parameter, found [here](https://docs.pokt.network/home/references/protocol-parameters#applicationstakeminimum).
+  parameter, found [here](https://docs.pokt.network/learn/protocol-parameters/#applicationstakeminimum).
 * `<relayChainIDs>`: A comma separated list of RelayChain Network Identifiers. Find the RelayChain Network
-  Identifiers [here](https://docs.pokt.network/home/references/supported-blockchains).
+  Identifiers [here](https://docs.pokt.network/supported-blockchains/).
 * `<chainID>`: The Pocket chain identifier; "mainnet" or "testnet".
 * `<fee>`:  An amount of uPOKT for the network.
 

--- a/doc/specs/cli/node.md
+++ b/doc/specs/cli/node.md
@@ -23,9 +23,9 @@ Arguments:
 
 * `<fromAddr>`: Target Address to stake.
 * `<amount>`: The amount of uPOKT to stake. Must be higher than the current value of the `StakeMinimum`  parameter,
-  found [here](https://docs.pokt.network/home/references/protocol-parameters#stakeminimum).
+  found [here](https://docs.pokt.network/learn/protocol-parameters/#stakeminimum).
 * `<relayChainIDs>`: A comma separated list of RelayChain Network Identifiers. Find the RelayChain Network
-  Identifiers [here](https://docs.pokt.network/home/references/supported-blockchains).
+  Identifiers [here](https://docs.pokt.network/supported-blockchains/).
 * `<serviceURI>`: The Service URI Applications will use to communicate with Nodes for Relays.
 * `<networkID>`: The Pocket chain identifier; "mainnet" or "testnet".
 * `<fee>`:  An amount of uPOKT for the network.
@@ -57,9 +57,9 @@ Arguments:
 * `<operatorPublicKey>`: operatorAddress is the only valid signer for blocks & relays.
 * `<outputAddress>`: outputAddress is where reward and staked funds are directed.
 * `<amount>`: The amount of uPOKT to stake. Must be higher than the current value of the `StakeMinimum`  parameter,
-  found [here](https://docs.pokt.network/home/references/protocol-parameters#stakeminimum).
+  found [here](https://docs.pokt.network/learn/protocol-parameters/#stakeminimum).
 * `<relayChainIDs>`: A comma separated list of RelayChain Network Identifiers. Find the RelayChain Network
-  Identifiers [here](https://docs.pokt.network/home/references/supported-blockchains).
+  Identifiers [here](https://docs.pokt.network/supported-blockchains/).
 * `<serviceURI>`: The Service URI Applications will use to communicate with Nodes for Relays.
 * `<networkID>`: The Pocket chain identifier; "mainnet" or "testnet".
 * `<fee>`:  An amount of uPOKT for the network.

--- a/doc/specs/cli/util.md
+++ b/doc/specs/cli/util.md
@@ -11,7 +11,7 @@ pocket util generate-chains
 ```
 
 Generate the chains.json file for RelayChain Network Identifiers. Find the RelayChain Network
-Identifiers [here](https://docs.pokt.network/home/references/supported-blockchains).
+Identifiers [here](https://docs.pokt.network/supported-blockchains/).
 
 Example output:
 
@@ -35,7 +35,7 @@ pocket util delete-chains
 ```
 
 Delete the chains.json file for RelayChain Network Identifiers. Find the RelayChain Network
-Identifiers [here](https://docs.pokt.network/home/references/supported-blockchains).
+Identifiers [here](https://docs.pokt.network/supported-blockchains/).
 
 Example Output:
 


### PR DESCRIPTION
A few documentation links were pointing to the old structure, and a few were 404ing. This PR fixes them.