### PR TITLE
minor: Use height in query account txs

### DIFF
--- a/app/cmd/cli/query.go
+++ b/app/cmd/cli/query.go
@@ -114,10 +114,10 @@ var queryTx = &cobra.Command{
 }
 
 var queryAccountTxs = &cobra.Command{
-	Use:   "account-txs <address> <page> <per_page> <prove (true | false)> <received (true | false)> <order (asc | desc)>",
+	Use:   "account-txs <address> <page> <per_page> <prove (true | false)> <received (true | false)> <order (asc | desc)> <height>",
 	Short: "Get the transactions sent by the address, paginated by page and per_page",
 	Long:  `Retrieves the transactions sent by the address`,
-	Args:  cobra.RangeArgs(1, 6),
+	Args:  cobra.RangeArgs(1, 7),
 	Run: func(cmd *cobra.Command, args []string) {
 		app.InitConfig(datadir, tmNode, persistentPeers, seeds, remoteCLIURL)
 		page := 0
@@ -125,6 +125,7 @@ var queryAccountTxs = &cobra.Command{
 		prove := false
 		received := false
 		order := "desc"
+		height := int64(0)
 		if len(args) >= 2 {
 			parsedPage, err := strconv.Atoi(args[1])
 			if err == nil {
@@ -158,6 +159,12 @@ var queryAccountTxs = &cobra.Command{
 				order = "desc"
 			}
 		}
+		if len(args) >= 7 {
+			parsedHeight, err := strconv.ParseInt(args[6], 10, 64)
+			if err == nil {
+				height = parsedHeight
+			}
+		}
 		var err error
 		params := rpc.PaginateAddrParams{
 			Address:  args[0],
@@ -166,6 +173,7 @@ var queryAccountTxs = &cobra.Command{
 			Received: received,
 			Prove:    prove,
 			Sort:     order,
+			Height:   height,
 		}
 		j, err := json.Marshal(params)
 		if err != nil {

--- a/app/cmd/cli/query.go
+++ b/app/cmd/cli/query.go
@@ -125,7 +125,7 @@ var queryAccountTxs = &cobra.Command{
 		prove := false
 		received := false
 		order := "desc"
-		height := int64(0)
+		height := int64(0) // height=0 is ignored and implies latest height
 		if len(args) >= 2 {
 			parsedPage, err := strconv.Atoi(args[1])
 			if err == nil {

--- a/app/cmd/rpc/query.go
+++ b/app/cmd/rpc/query.go
@@ -86,6 +86,7 @@ type PaginateAddrParams struct {
 	Received bool   `json:"received,omitempty"`
 	Prove    bool   `json:"prove,omitempty"`
 	Sort     string `json:"order,omitempty"`
+	Height   int64  `json:"height,omitempty"`
 }
 
 type PaginatedHeightParams struct {
@@ -317,9 +318,9 @@ func AccountTxs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var res *core_types.ResultTxSearch
 	var err error
 	if !params.Received {
-		res, err = app.PCA.QueryAccountTxs(params.Address, params.Page, params.PerPage, params.Prove, params.Sort)
+		res, err = app.PCA.QueryAccountTxs(params.Address, params.Page, params.PerPage, params.Prove, params.Sort, params.Height)
 	} else {
-		res, err = app.PCA.QueryRecipientTxs(params.Address, params.Page, params.PerPage, params.Prove, params.Sort)
+		res, err = app.PCA.QueryRecipientTxs(params.Address, params.Page, params.PerPage, params.Prove, params.Sort, params.Height)
 	}
 	if err != nil {
 		WriteErrorResponse(w, 400, err.Error())

--- a/app/query.go
+++ b/app/query.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	messageSenderQuery     = "tx.signer='%s'"
+	heightQuery            = "tx.height=%d"
 	transferRecipientQuery = "tx.recipient='%s'"
 	txHeightQuery          = "tx.height=%d"
 )
@@ -48,7 +49,7 @@ func (app PocketCoreApp) QueryTx(hash string, prove bool) (res *core_types.Resul
 	return
 }
 
-func (app PocketCoreApp) QueryAccountTxs(addr string, page, perPage int, prove bool, sort string) (res *core_types.ResultTxSearch, err error) {
+func (app PocketCoreApp) QueryAccountTxs(addr string, page, perPage int, prove bool, sort string, height int64) (res *core_types.ResultTxSearch, err error) {
 	tmClient := app.GetClient()
 	defer func() { _ = tmClient.Stop() }()
 	_, err = hex.DecodeString(addr)
@@ -56,11 +57,14 @@ func (app PocketCoreApp) QueryAccountTxs(addr string, page, perPage int, prove b
 		return nil, err
 	}
 	query := fmt.Sprintf(messageSenderQuery, addr)
+	if height > 0 {
+		query = fmt.Sprintf("%s AND %s", query, fmt.Sprintf(heightQuery, height))
+	}
 	page, perPage = checkPagination(page, perPage)
 	res, err = tmClient.TxSearch(query, prove, page, perPage, checkSort(sort))
 	return
 }
-func (app PocketCoreApp) QueryRecipientTxs(addr string, page, perPage int, prove bool, sort string) (res *core_types.ResultTxSearch, err error) {
+func (app PocketCoreApp) QueryRecipientTxs(addr string, page, perPage int, prove bool, sort string, height int64) (res *core_types.ResultTxSearch, err error) {
 	tmClient := app.GetClient()
 	defer func() { _ = tmClient.Stop() }()
 	_, err = hex.DecodeString(addr)
@@ -68,6 +72,9 @@ func (app PocketCoreApp) QueryRecipientTxs(addr string, page, perPage int, prove
 		return nil, err
 	}
 	query := fmt.Sprintf(transferRecipientQuery, addr)
+	if height > 0 {
+		query = fmt.Sprintf("%s AND %s", query, fmt.Sprintf(heightQuery, height))
+	}
 	page, perPage = checkPagination(page, perPage)
 	res, err = tmClient.TxSearch(query, prove, page, perPage, checkSort(sort))
 	return

--- a/e2e/tests/query.feature
+++ b/e2e/tests/query.feature
@@ -51,7 +51,7 @@ Feature: Pocket Query Commands
   Scenario: To query an existing account txs
 	Given the user is running the network "single_node_network"
 	And the user has a pocket client
-	When the user runs the command "query account-txs c7b6a62385f8999c0cb63ad9cb464ee730c597b1 0 1 0 0" against validator 0
+	When the user runs the command "query account-txs c7b6a62385f8999c0cb63ad9cb464ee730c597b1 0 1 0 0 0" against validator 0
 	Then the user should be able to see standard output containing "page_count"
 	And the user should be able to see standard output containing "total_txs"
 	And the pocket client should have exited without error
@@ -59,7 +59,7 @@ Feature: Pocket Query Commands
   Scenario: To query an existing account txs, wrong address
 	Given the user is running the network "single_node_network"
 	And the user has a pocket client
-	When the user runs the command "query account-txs c7b6a62385f8999c0cb63ad9cb464ee730c597bw 0 1 0 0" against validator 0
+	When the user runs the command "query account-txs c7b6a62385f8999c0cb63ad9cb464ee730c597bw 0 1 0 0 0" against validator 0
 	Then the user should be able to see standard output containing "encoding/hex: invalid byte:"
 	And the pocket client should have exited without error
 

--- a/types/indexer.go
+++ b/types/indexer.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
+
 	"github.com/jordanorelli/lexnum"
 	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
-	"math"
 )
 
 var (
@@ -25,6 +26,10 @@ var (
 )
 
 const (
+	// Transaction(tx) Block height index key.
+	//
+	// Note: Block height is cast as int when querying using the tx height index due to the lexicographic encoder library,
+	// this is safe because v0 block height should never exceed 2^63-1 on 64-bit systems or 2^31-1 on 32-bit systems.
 	TxHeightKey         = "tx.height"
 	TxSignerKey         = "tx.signer"
 	TxRecipientKey      = "tx.recipient"
@@ -302,7 +307,7 @@ func prefixKeyForSignerAndHeight(signer Address, height int64) []byte {
 	return []byte(fmt.Sprintf("%s/%s/%s",
 		TxSignerKey,
 		signer,
-		elenEncoder.EncodeInt(int(height)), // totally safe right?
+		elenEncoder.EncodeInt(int(height)),
 	))
 }
 
@@ -327,7 +332,7 @@ func prefixKeyForRecipientAndHeight(recipient Address, height int64) []byte {
 	return []byte(fmt.Sprintf("%s/%s/%s",
 		TxRecipientKey,
 		recipient,
-		elenEncoder.EncodeInt(int(height)), // totally safe right?
+		elenEncoder.EncodeInt(int(height)),
 	))
 }
 


### PR DESCRIPTION
This PR Adds a new query parameter to the accounttxs endpoint to allow querying for account (send/received) txs starting at a certain height.

This is not a breaking change, as the new parameter is optional. If it is not provided, the endpoint will behave as it did before.

It is a performance improvement, as it allows the client to specify a height to start querying from, instead of having to query all txs and then filter them out.

You can try and verify by running the following commands:

**CURRENT_POKT_RPC_URL**= # replace with current rpc url
**POKT_RPC_WITH_HEIGHT_INDEX_URL**= # replace with new rpc url built from this branch

Tested using the SendNodes POPs address.

# pull hash and height of first and last tx

```sh
curl --request POST \
 --url http://CURRENT_POKT_RPC_URL/v1/query/accounttxs \
 --header 'Content-Type: application/json' \
 --data '{
"address": "cb6ff4204f8a93e89759c22a9e0f8896f8561379",
"page": 1,
"per_page": 10000,
"received": true,
"prove": false,
"order": "asc"
}' | jq '.txs | first, last | [.hash, .height]'

# example
#   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#                                  Dload  Upload   Total   Spent    Left  Speed
#   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
# 100 12.5M    0 12.5M  100   137  1364k     14  0:00:09  0:00:09 --:--:-- 4014k
# [
#   "1F6511B8E975C9189E4592C44CA0D8039B3861BC550EE96378D29BC43CE8E552",
#   86099
# ]
# [
#   "CCFB5D49009D37BFB3E472FBBD6E79791CB0B4E972765926074F521CF19A4812",
#   82654
# ]
```

# query new version with last height

```sh
curl --request POST \
  --url http://POKT_RPC_WITH_HEIGHT_INDEX_URL/v1/query/accounttxs \
  --header 'Content-Type: application/json' \
  --data '{
  "address": "cb6ff4204f8a93e89759c22a9e0f8896f8561379",
  "page": 1,
  "per_page": 10000,
  "received": true,
  "prove": false,
  "order": "asc",
  "height": 82654
}' | jq '.txs | first, last | [.hash, .height]'

# should match old version
#   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#                                  Dload  Upload   Total   Spent    Left  Speed
# 100 12.5M    0 12.5M  100   168  10.7M    143  0:00:01  0:00:01 --:--:-- 10.7M
# [
#   "1F6511B8E975C9189E4592C44CA0D8039B3861BC550EE96378D29BC43CE8E552",
#   86099
# ]
# [
#   "CCFB5D49009D37BFB3E472FBBD6E79791CB0B4E972765926074F521CF19A4812",
#   82654
# ]
```

# double check old version still matches

```sh
curl --request POST \
  --url https://POKT_RPC_WITH_HEIGHT_INDEX_URL/v1/query/accounttxs \
  --header 'Content-Type: application/json' \
  --data '{
  "address": "cb6ff4204f8a93e89759c22a9e0f8896f8561379",
  "page": 1,
  "per_page": 10000,
  "received": true,
  "prove": false,
  "order": "asc"
}' | jq '.txs | first, last | [.hash, .height]'

# should match old version
# [
#   "1F6511B8E975C9189E4592C44CA0D8039B3861BC550EE96378D29BC43CE8E552",
#   86099
# ]
# [
#   "CCFB5D49009D37BFB3E472FBBD6E79791CB0B4E972765926074F521CF19A4812",
#   82654
# ]
```
