### PR TITLE
Probabilistic Proofs - Model Claim and Stake Data for Parameter Thresholds

### DIFF
--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -50,12 +50,11 @@ Three new governance parameters will need to be added:
 ### Parameter Usage
 
 $$
-Probably(ProofRequired)=\left\{
-\begin{array}{ll}
-ProbabilityOfProofRequest &\text{if } Claim < ProofRequiredThreshold  \\
-1.0 &\text{if } Claim >= ProofRequiredThreshold.
-\end{array}
-\right.
+Probably(ProofRequired) =
+  \begin{cases}
+    ProbabilityOfProofRequest &\text{if } Claim < ProofRequiredThreshold  \\
+    1 &\text{if } Claim >= ProofRequiredThreshold.
+  \end{cases}
 $$
 
 ### Flow
@@ -125,6 +124,7 @@ The definition for success is taken from the Network's point of view.
   - Servicer submits a false claim and gets away with it
   - Servicer submits a true claim, but fails to prove it
 
+<!--
 The types of questions we can ask are:
 
 - What is the stopping condition?
@@ -134,6 +134,7 @@ The types of questions we can ask are:
 - How many success until N failures?
 - How much scalability does the network need?
 - With what likelihood should an attacker get away?
+-->
 
 ### Example
 
@@ -151,11 +152,12 @@ Since each claim is independent, an attacker would never submit a `Claim` exceed
 A [Geometric_distribution](https://en.wikipedia.org/wiki/Geometric_distribution) is used to identify the probability of `k` failures (sample space containing an attacker getting away) until a single success (an attacker is caught).
 
 $$ p = ProofRequestProbability $$
-$$ q = 1 - p $$
-$$ Pr(X=k) = (1-p)^{k-1}p $$
-$$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
 
-#### Model Visualization
+$$ q = 1 - p $$
+
+$$ Pr(X=k) = (1-p)^{k-1}p $$
+
+$$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
 
 ![download](https://user-images.githubusercontent.com/1892194/220803154-90dcdd6b-8141-40d2-9cca-ed27a995fcfb.png)
 
@@ -172,7 +174,9 @@ _TODO(olshansky): Look at claims data to figure out the value for ProofRequireme
 `Pr(X=k) > 0` must be greater than 0 while minimizing `k` as much as possible, so it is selected at approximately `0.01.`.
 
 $$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
+
 $$ k = \frac{ln(\frac{0.01}{0.25})}{ln(1-0.25)} + 1 $$
+
 $$ k ≈ 12.19 $$
 
 Selecting `k = 12` implies that there is an `~1%` of 12 failures (includes the sample space where an attacker gets away) until a single success (an attacker is caught). To deter this behaviour, the `ProofMissingPenalty` should be selected as 12 times `ProofRequirementThreshold`.

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -157,15 +157,24 @@ Since each claim is independent, an attacker would never submit a `Claim` exceed
 
 A [Geometric_distribution](https://en.wikipedia.org/wiki/Geometric_distribution) is used to identify the probability of `k` failures (sample space containing an attacker getting away) until a single success (an attacker is caught).
 
+### Geometric PDF
+
 $$ p = ProofRequestProbability $$
 
+$$ Pr(X<=k) = 1 - (1 - p)^k $$
+
+![Geometric PDF](https://user-images.githubusercontent.com/1892194/221075888-1092d3d3-b530-416d-8112-7957057a35df.png)
+
+### Geometric CDF
+
+$$ p = ProofRequestProbability $$
 $$ q = 1 - p $$
 
 $$ Pr(X=k) = (1-p)^{k-1}p $$
 
 $$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
 
-![download](https://user-images.githubusercontent.com/1892194/220803154-90dcdd6b-8141-40d2-9cca-ed27a995fcfb.png)
+![Geometric CDF]()
 
 ### Selecting Values
 
@@ -216,8 +225,15 @@ To answer this question, we need to:
 **A**: The onus is on the Servicer to upkeep their infrastructure. This is a tradeoff that must be considered as a risk/reward in exchange for the network's growth.
 
 <!-- Supporting Python Code
+
+## Appendix
+
+### Python Code - Geometric PDF
+
+```python
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib import cm
 
 # Define the function
 def f(x, p):
@@ -225,15 +241,24 @@ def f(x, p):
 
 # Define the range of x values to plot
 x = np.linspace(0.01, 1, 200)
+xp = np.linspace(0.01, 1, 10)
 
 # Plot the function for p = 0.2, p = 0.5, and p = 0.8
-for p in [0.25, 0.5, 0.75, 0.9]:
+ps = [0.25, 0.5, 0.75, 0.9]
+colors = cm.get_cmap('hsv', len(ps)+1)
+for i, p in enumerate(ps):
+    color = colors(i)
     y = f(x, p)
-    plt.plot(x, y, label=f'p = {p}')
+    yp = f(xp, p)
+    plt.plot(x, y, label=f'p = {p}', color=color)
+    # Select only the points where y > 0 and plot them as dots
+    x_pos = xp[np.where(yp > 0)]
+    y_pos = yp[np.where(yp > 0)]
+    plt.plot(x_pos, y_pos, 'o', color=color)
 
 
 # Add a horizontal line at y = 0
-plt.axhline(y=0, color='red', linestyle='--')
+plt.axhline(y=0, color='gray', linestyle='--')
 
 # Add legend, axis labels, and title
 plt.legend()
@@ -243,5 +268,8 @@ plt.title('Number of failures until a single success')
 
 # Display the plot
 plt.show()
+```
+
+### Python Code - Geometric CDF
 
 -->

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -1,5 +1,11 @@
 # Probabilistic Proofs <!-- omit in toc -->
 
+<p align="center">
+    @olshansk - Daniel Olshansky<br>
+    @RawthiL - Ramiro R. C.<br>
+    Feb 2023
+</p>
+
 This is a specification & proposal that will be submitted to [forum.pokt.network](https://forum.pokt.network) after peer-review.
 
 **tl;dr Values Selected**

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -18,7 +18,7 @@ This is a specification & proposal that will be submitted to [forum.pokt.network
 
 **The question being answered by the distribution**: What is the probability of the network (i.e. the protocol) failing `k` times or less(i.e. handling a normal claim or not catching an attacker) until a single success (i.e. catching an attacker).
 
-**Answer**: Selecting `k = 16` and `ProofRequirementThreshold = 20 POKT` implies that if an attacker continues submitting claims for `19.99 POKT` or less, they will get caught `99.99%` of the time, and will be penalized for `320 POKT`.
+**Answer**: Selecting `k = 16` and `ProofRequirementThreshold = 20 POKT` implies that if an attacker continues submitting claims for `19.99 POKT` or less, they will get caught `99%` of the time, and will be penalized for `320 POKT`.
 
 ## Table of Contents <!-- omit in toc -->
 

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -2,6 +2,14 @@
 
 This is a specification & proposal that will be submitted to [forum.pokt.network](https://forum.pokt.network) after peer-review.
 
+**tl;dr Values Selected**
+
+- `ProofRequirementThreshold` = `2σ` above network claim Claim `μ`
+- `ProofRequestProbability` = `0.25`
+- `Pr(X=k)` = `0.01`
+- `k` (num failures) = `12`
+- `ProofMissingPenalty` = `ProofRequirementThreshold * k`
+
 - [Summary](#summary)
 - [Specification](#specification)
   - [Governance Parameters](#governance-parameters)
@@ -14,7 +22,6 @@ This is a specification & proposal that will be submitted to [forum.pokt.network
   - [Example](#example)
   - [Model](#model)
   - [Selecting Values](#selecting-values)
-    - [Values Selected](#values-selected)
     - [Calculation](#calculation)
 - [Dissenting Opinions](#dissenting-opinions)
   - [Malicious Attackers Bloating State](#malicious-attackers-bloating-state)
@@ -24,7 +31,7 @@ This is a specification & proposal that will be submitted to [forum.pokt.network
 
 The number of relays in Pocket Network (V0) is limited by the amount of block space utilized by Claim Proofs. The estimations done [here](https://docs.google.com/document/d/1QcsPfhj636zBazw2jAay8H6gdBKXcIMmohY0o321hhQ/edit) approximated it to be ~3B/day.
 
-Several solutions were proposed [in this document](https://docs.google.com/document/d/1uBomaVieGAjsyHeqSlwmqOyPOln1CemVlWXZjQXUMRY/edit). This proposal outlines an alternate solution: Probabilistic Proofs.
+Several solutions were proposed [in this document](https://docs.google.com/document/d/1uBomaVieGAjsyHeqSlwmqOyPOln1CemVlWXZjQXUMRY/edit). This proposal outlines an alternate solution: **Probabilistic Proofs**.
 
 In order for Servicers to be rewarded for their work, a fraction of the Claims submitted on-chain will require a Proof to also be submitted-on chain probabilistically under the random Oracle model.
 
@@ -152,19 +159,11 @@ $$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
 
 ### Selecting Values
 
-#### Values Selected
-
-- `ProofRequirementThreshold` = `2σ` above network claim Claim `μ`
-- `ProofRequestProbability` = `0.25`
-- `Pr(X=k)` = `0.01`
-- `k` (num failures) = `12`
-- `ProofMissingPenalty` = `ProofRequirementThreshold * k`
-
 #### Calculation
 
-`ProofRequirementThreshold` should be as small as possible so that most such that most Claims for into the probabilistic bucket, while also balancing out penalties that may be too large for faulty honest Servicers. It will be selected to be `2σ` above the Claim `μ` such that `97.3%` fall into the `ProofRequestProbability` part of the piecewise function.
-
 _TODO(olshansky): Look at claims data to figure out the value for ProofRequirementThreshold_
+
+`ProofRequirementThreshold` should be as small as possible so that most such that most Claims for into the probabilistic bucket, while also balancing out penalties that may be too large for faulty honest Servicers. It will be selected to be `2σ` above the Claim `μ` such that `97.3%` fall into the `ProofRequestProbability` part of the piecewise function.
 
 `ProofRequestProbability (p)` is selected as `0.25` to enable scaling the network by `4x`.
 
@@ -176,9 +175,9 @@ $$ k ≈ 12.19 $$
 
 Selecting `k = 12` implies that there is an `~1%` of 12 failures (includes the sample space where an attacker gets away) until a single success (an attacker is caught). To deter this behaviour, the `ProofMissingPenalty` should be selected as 12 times `ProofRequirementThreshold`.
 
-To answer this question, we need to select:
+To answer this question, we need to:
 
-- Pick `p` - variable for scaling the network; e.g. 0.25 => 4x networkscale
+- Pick `p` - variable for scaling the network (e.g. 0.25 => 4x network scale)
 - Select `Pr(X=k)` - the likelihood of `k` failures
 - Introduce `BurnForFailedClaimSubmission` - penalty for getting caught in falsifying a claim (or failing to submit a real claim)
 
@@ -195,11 +194,13 @@ To answer this question, we need to select:
 ### Malicious Attackers Bloating State
 
 **Q**: Adversarial actors may continue submitting Proofs in excess of what's required to bloat the state of the chain.
+
 **A**: In the Random Oracle model, only pseudo-randomly selected Claims seeded by on-chain data (e.g. LastBlockHash, hash(claim), ServicerPubKey, etc...) will be included by block proposers.
 
 ### Honest Servicers Getting Burnt
 
 **Q**: An honest Servicer that submitted a Claim, but failed to submit a Proof within `pocketcore/ClaimExpiration` will be burnt. In today's model, they will only lose the rewards for the unproven Claim.
+
 **A**: The onus is on the Servicer to upkeep their infrastructure. This is a tradeoff that must be considered as a risk/reward in exchange for the network's growth.
 
 <!-- Supporting Python Code

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -155,6 +155,8 @@ $$ q = 1 - p $$
 $$ Pr(X=k) = (1-p)^{k-1}p $$
 $$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
 
+#### Model Visualization
+
 ![download](https://user-images.githubusercontent.com/1892194/220803154-90dcdd6b-8141-40d2-9cca-ed27a995fcfb.png)
 
 ### Selecting Values

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -2,7 +2,7 @@
 
 <p align="center">
     @olshansk - Daniel Olshansky<br>
-    @RawthiL - Ramiro R. C.<br>
+    @RawthiL - Ramiro Rodríguez Colmeiro<br>
     Feb 2023
 </p>
 

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -148,6 +148,8 @@ $$ q = 1 - p $$
 $$ Pr(X=k) = (1-p)^{k-1}p $$
 $$ k = \frac{ln(\frac{Pr(X=k)}{p})}{ln(1-p)} + 1 $$
 
+![download](https://user-images.githubusercontent.com/1892194/220803154-90dcdd6b-8141-40d2-9cca-ed27a995fcfb.png)
+
 ### Selecting Values
 
 #### Values Selected
@@ -199,3 +201,34 @@ To answer this question, we need to select:
 
 **Q**: An honest Servicer that submitted a Claim, but failed to submit a Proof within `pocketcore/ClaimExpiration` will be burnt. In today's model, they will only lose the rewards for the unproven Claim.
 **A**: The onus is on the Servicer to upkeep their infrastructure. This is a tradeoff that must be considered as a risk/reward in exchange for the network's growth.
+
+<!-- Supporting Python Code
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Define the function
+def f(x, p):
+    return np.log(x/p) / np.log(1-p)
+
+# Define the range of x values to plot
+x = np.linspace(0.01, 1, 200)
+
+# Plot the function for p = 0.2, p = 0.5, and p = 0.8
+for p in [0.25, 0.5, 0.75, 0.9]:
+    y = f(x, p)
+    plt.plot(x, y, label=f'p = {p}')
+
+
+# Add a horizontal line at y = 0
+plt.axhline(y=0, color='red', linestyle='--')
+
+# Add legend, axis labels, and title
+plt.legend()
+plt.xlabel('Probability(X=k)')
+plt.ylabel('k (num failures)')
+plt.title('Number of failures until a single success')
+
+# Display the plot
+plt.show()
+
+-->

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -16,7 +16,7 @@ This is a specification & proposal that will be submitted to [forum.pokt.network
 - `ProofRequirementThreshold` = `20 POKT`; selected to a value that is above p95 of all POKT claims
 - `ProofMissingPenalty` = `320 POKT`; calculated via `ProofRequirementThreshold * k` to deter malicious behaviour
 
-**The question being answered by the distribution**: What is the probability of the network (i.e. the protocol) failing `k` times or less(i.e. handling a normal claim or not catching an attacker) until a single success (i.e. catching an attacker).
+**The question being answered by the distribution**: What is the probability of the protocol trusting (i.e. failing) `k` Claims or less (i.e. handling a normal claim or not catching an attacker) until a single penalty enforcement (i.e. successfully catching an attacker).
 
 **Answer**: Selecting `k = 16` and `ProofRequirementThreshold = 20 POKT` implies that if an attacker continues submitting claims for `19.99 POKT` or less, they will get caught `99%` of the time, and will be penalized for `320 POKT`.
 
@@ -143,18 +143,6 @@ The definition for success is taken from the Network's point of view.
   - Servicer submits a false claim and gets away with it
   - Servicer submits a true claim, but fails to prove it
 
-<!--
-The types of questions we can ask are:
-
-- What is the stopping condition?
-- How many success until a single failure?
-- How many failures until a single success?
-- How many failures until N success?
-- How many success until N failures?
-- How much scalability does the network need?
-- With what likelihood should an attacker get away?
--->
-
 ### Example
 
 Let `ProofRequirementThreshold = 100 POKT`
@@ -197,7 +185,7 @@ $$ k = \frac{log(1 - P(X<=k))}{log(1 - p)} $$
 
 #### Calculation
 
-`ProofRequirementThreshold` should be as small as possible so that most such that most Claims for into the probabilistic bucket, while also balancing out penalties that may be too large for faulty honest Servicers. It will be selected to be `2σ` above the Claim `μ` such that `97.3%` fall into the `ProofRequestProbability` part of the piecewise function.
+`ProofRequirementThreshold` should be as small as possible so that most such that most Claims for into the probabilistic bucket, while also balancing out penalties that may be too large for faulty honest Servicers. Ideally, it should be selected to be `2σ` above the Claim `μ` such that `97.3%` fall into the `ProofRequestProbability` part of the piecewise function. However, as seen in the Appendix, the POKT Claim distribution does not follow a normal distribution. Instead, 20 POKT was selected since it is greater than `p95` of POKT claim using the data collected.
 
 `ProofRequestProbability (p)` is selected as `0.25` to enable scaling the network by `4x`.
 

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -18,6 +18,8 @@ This is a specification & proposal that will be submitted to [forum.pokt.network
 
 **The question being answered by the distribution**: What is the probability of the network (i.e. the protocol) failing `k` times or less(i.e. handling a normal claim or not catching an attacker) until a single success (i.e. catching an attacker).
 
+**Answer**: Selecting `k = 16` implies that `99%` of the time, an attacker will get a penalty of `BurnForFailedClaimSubmission`, making it not worthwhile to take the risk.
+
 ## Table of Contents <!-- omit in toc -->
 
 - [Summary](#summary)

--- a/docs/proposals/probabilistic_proofs.md
+++ b/docs/proposals/probabilistic_proofs.md
@@ -1,0 +1,148 @@
+# Probabilistic Proofs <!-- omit in toc -->
+
+- [Background \& Setup](#background--setup)
+- [Flow](#flow)
+- [Modelling the Attack](#modelling-the-attack)
+  - [Definitions](#definitions)
+  - [Questions](#questions)
+  - [Example](#example)
+    - [Setup](#setup)
+    - [Model](#model)
+      - [Burn Amount](#burn-amount)
+  - [Solution](#solution)
+- [\[WIP - do not read\]](#wip---do-not-read)
+  - [Alt Solutions (Dissenting Opinions)](#alt-solutions-dissenting-opinions)
+  - [Alt Attacks](#alt-attacks)
+
+## Background & Setup
+
+TODO: Copy over context from [notion](https://www.notion.so/Idea-Probabilistic-Proofs-f3fa87447f1c4c63b38b1ff46c049f67#d1f7699135fd438cb2251fa11a91f8cb)
+
+## Flow
+
+```mermaid
+---
+title: Probabilistic Proof
+---
+stateDiagram-v2
+    state claim_threshold <<choice>>
+    state random_selection <<choice>>
+
+    SC: Submit Claim
+    NP: Proof NOT Required
+    PR: Proof Required
+    DR: Distribute Reward
+    B: Peanlty / Burn
+
+    [*] --> SC
+    SC --> claim_threshold
+
+    claim_threshold --> PR : Claim >= ProofRequiredThreshold
+    claim_threshold --> random_selection: Claim < ProofRequiredThreshold
+
+    random_selection --> NP: P(1-ProbabilityOfProofRequest)
+    random_selection --> PR: P(ProbabilityOfProofRequest)
+
+    PR --> DR: Proof available
+    PR --> B: Proof NOT available<br>(honest or malicious)
+
+    NP --> DR
+```
+
+## Modelling the Attack
+
+### Definitions
+
+Define the sample space with a single definition success, and failure capturing everything else.
+
+**Success**: Submit a false claim and get caught
+
+**Failure**:
+
+- (honest) Submit a true claim and prove it
+- (honest) Submit a true claim and have no requirement to prove it
+- (steal): Submit a false claim and get away with it
+- (unlucky-tbd): Submit a true claim, but fail to prove it when required (e.g. technical reasons)
+
+**TBD (be honest but unlucky)**:
+
+### Questions
+
+- How many success until a single failure?
+- How many failures until a single success?
+- How many failures until N success?
+- How many success until N failures?
+- What is the stopping condition?
+- What should the burn amount be for failing to submit a required claim?
+- What should `ProofRequiredThreshold` be?
+- What should `ProbabilityOfProofRequest` be?
+- With what probability should a malicious servicer get away?
+
+### Example
+
+#### Setup
+
+The proofs for determining the appropriate values of `ProbabilityOfProofRequest` and `ProofRequiredThreshold` will be done by demonstrating the most optimal malicious behaviour an attacker should follow by example.
+
+Assume `ProofRequiredThreshold = 100 POKT`. If the `Claim` is greater than or equal to `100 POKT`, a proof is mandatory. Therefore, the attacker can freeload by submitting claims for `99.99 POKT` and hope they never get caught. If they do get caught, the penalty (i.e. burn) should exceed the reward.
+
+Since the attacker will never pass the `ProofRequiredThreshold` threshold, they can only get caught with `ProbabilityOfProofRequest` likelihood.
+
+#### Model
+
+The value for `ProofRequiredThreshold` is ignored since it "short circuits" the model.
+
+We can use a [Geometric_distribution](https://en.wikipedia.org/wiki/Geometric_distribution) and identify the probability of `N` failures until a single success.
+
+$$ p = ProbabilityOfProofRequest $$
+$$ q = 1 - p $$
+$$ Pr(X=k) = (1-p)^{k-1}p $$
+$$ k = \frac{log(1-Pr(X=k))}{log(1-p)} $$
+$$ k = \frac{log(1-Pr(X=k))}{log(q)} $$
+
+To answer this question, we need to:
+
+- Pick `p` - variable for scaling the network: 0.25 => 4x scale
+- Select `Pr(X=k)` - the likelihood of `k` failures
+- Introduce `BurnForFailedClaimSubmission` - penalty
+
+```
+  p = 0.25 => 4x scale
+  0.99 = (1-0.25)\*_(x-1) _ 0.25
+  x ≈ 4.766 = round(5)
+  Set burn to threshold \* x
+```
+
+##### Burn Amount
+
+`BurnForFailedClaimSubmission` is the penalty after `pocketcore/ClaimExpiration` expires. The validators will need to query all claims
+expiring at the current height and apply the appropriate penalties.
+
+### Solution
+
+`ProofRequiredThreshold` - Should be set to a value whereby that that is `2σ` greater than the mean claim. This will mean that the other `97.3%` of claims will be subject to `ProbabilityOfProofRequest`.
+
+`ProbabilityOfProofRequest` -
+
+ProofRequiredThreshold
+
+## [WIP - do not read]
+
+### Alt Solutions (Dissenting Opinions)
+
+- Warnings: Allow a tolerance (e.g. 2 warnings) until a burn happens.
+  - Too complex
+- Unclaim: Servicers can submit an unclaim message.
+  - Too much state
+
+### Alt Attacks
+
+- A: Malicious users submit claims to bloat state?
+- S: Validators need to disallow including it in the block if proof is not required
+
+- Specify: how many times can I succeed? (i.e. steal pokt)
+- How many times can I fail? (i.e. get caught) -> only once
+
+```
+
+```


### PR DESCRIPTION
Pocket Network V0 has a theoretical cap of 3B average daily relays. This is primarily caused by the bloat of Proofs within a Block, which is part of Pocket's fundamental Claim & Proof relay validation lifecycle. This document outlines a theoretical proposal to help scale Pocket Network V0 by several magnitudes through a Probabilistic Proof mechanism. This reduces the amount of space taken up by Proofs within a Block, and does not cause a linear increase in the network's storage requirements as the number of relays grow.

Fixes #1523