### PR TITLE
Clear the global session cache when a node is unjailed

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -50,6 +50,7 @@ const (
 	BlockSizeModifyKey           = "BLOCK"
 	RSCALKey                     = "RSCAL"
 	VEDITKey                     = "VEDIT"
+	ClearUnjailedValSessionKey   = "CRVAL"
 )
 
 func GetCodecUpgradeHeight() int64 {
@@ -279,6 +280,24 @@ func (cdc *Codec) IsAfterNamedFeatureActivationHeight(height int64, key string) 
 // IsOnNamedFeatureActivationHeight Note: includes the actual upgrade height
 func (cdc *Codec) IsOnNamedFeatureActivationHeight(height int64, key string) bool {
 	return UpgradeFeatureMap[key] != 0 && height == UpgradeFeatureMap[key]
+}
+
+// IsOnNamedFeatureActivationHeightWithTolerance is used to enable certain
+// business logic within some tolerance (i.e. only a few blocks) of feature
+// activation to have more confidence in the feature's release and avoid
+// non-deterministic or hard-to-predict behaviour.
+func (cdc *Codec) IsOnNamedFeatureActivationHeightWithTolerance(
+	height int64,
+	featureKey string,
+	tolerance int64,
+) bool {
+	upgradeHeight := UpgradeFeatureMap[featureKey]
+	if upgradeHeight == 0 {
+		return false
+	}
+	minHeight := upgradeHeight - tolerance
+	maxHeight := upgradeHeight + tolerance
+	return height >= minHeight && height <= maxHeight
 }
 
 // Upgrade Utils for feature map

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1,0 +1,58 @@
+package codec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This test should never be run in parallel because this replaces
+// the global variable `UpgradeFeatureMap`.
+func TestCodec_IsOnNamedFeatureActivationHeightWithTolerance(t *testing.T) {
+	upgradeKey := ClearUnjailedValSessionKey
+	upgradeHeight := int64(20000)
+	tolerance := int64(5)
+
+	// have to init global map / not mock friendly.
+	originalUpgradeFeatureMap := UpgradeFeatureMap
+	UpgradeFeatureMap = map[string]int64{upgradeKey: upgradeHeight}
+	t.Cleanup(func() {
+		UpgradeFeatureMap = originalUpgradeFeatureMap
+	})
+
+	codec := NewCodec(nil)
+
+	// Test zero values / out of bounds
+	assert.False(t, codec.IsOnNamedFeatureActivationHeightWithTolerance(
+		0,
+		upgradeKey,
+		tolerance,
+	))
+	assert.False(t, codec.IsOnNamedFeatureActivationHeightWithTolerance(
+		upgradeHeight-tolerance-1,
+		upgradeKey,
+		tolerance,
+	))
+	assert.False(t, codec.IsOnNamedFeatureActivationHeightWithTolerance(
+		upgradeHeight+tolerance+1,
+		upgradeKey,
+		tolerance,
+	))
+
+	// Test in bounds
+	assert.True(t, codec.IsOnNamedFeatureActivationHeightWithTolerance(
+		upgradeHeight-tolerance,
+		upgradeKey,
+		tolerance,
+	))
+	assert.True(t, codec.IsOnNamedFeatureActivationHeightWithTolerance(
+		upgradeHeight,
+		upgradeKey,
+		tolerance,
+	))
+	assert.True(t, codec.IsOnNamedFeatureActivationHeightWithTolerance(
+		upgradeHeight+tolerance,
+		upgradeKey,
+		tolerance,
+	))
+}

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pokt-network/pocket-core/types/module"
 	"github.com/pokt-network/pocket-core/x/gov/keeper"
 	"github.com/pokt-network/pocket-core/x/gov/types"
+	pc "github.com/pokt-network/pocket-core/x/pocketcore/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -119,6 +120,18 @@ func (am AppModule) ExportGenesis(ctx sdk.Ctx) json.RawMessage {
 func (am AppModule) BeginBlock(ctx sdk.Ctx, req abci.RequestBeginBlock) {
 
 	ActivateAdditionalParametersACL(ctx, am)
+
+	// Around this upgrade height, we clear the global session cache to prevent
+	// any non-deterministic cache consistency issues.
+	// See #1529 for more details.
+	const clearSessionCacheTolerance = 2
+	if am.keeper.GetCodec().IsOnNamedFeatureActivationHeightWithTolerance(
+		ctx.BlockHeight(),
+		codec.ClearUnjailedValSessionKey,
+		clearSessionCacheTolerance,
+	) {
+		pc.ClearSessionCache(pc.GlobalSessionCache)
+	}
 
 	u := am.keeper.GetUpgrade(ctx)
 	if ctx.AppVersion() < u.Version && ctx.BlockHeight() >= u.UpgradeHeight() && ctx.BlockHeight() != 0 {

--- a/x/nodes/keeper/valStateChanges.go
+++ b/x/nodes/keeper/valStateChanges.go
@@ -652,6 +652,8 @@ func (k Keeper) UnjailValidator(ctx sdk.Ctx, addr sdk.Address) {
 		k.Logger(ctx).Error(fmt.Sprintf("cannot unjail already unjailed validator, validator: %v at height %d\n", validator, ctx.BlockHeight()))
 		return
 	}
+	// clear cache
+	k.PocketKeeper.ClearSessionCache()
 	validator.Jailed = false
 	k.SetValidator(ctx, validator)
 	k.ResetValidatorSigningInfo(ctx, addr)

--- a/x/pocketcore/types/service_test.go
+++ b/x/pocketcore/types/service_test.go
@@ -2,17 +2,14 @@ package types
 
 import (
 	"encoding/hex"
-	"github.com/pokt-network/pocket-core/codec"
-	types2 "github.com/pokt-network/pocket-core/codec/types"
-	"github.com/pokt-network/pocket-core/crypto"
-	exported2 "github.com/pokt-network/pocket-core/x/apps/exported"
-	"github.com/pokt-network/pocket-core/x/auth"
-	"github.com/pokt-network/pocket-core/x/gov"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/pokt-network/pocket-core/codec"
+	"github.com/pokt-network/pocket-core/crypto"
 	sdk "github.com/pokt-network/pocket-core/types"
+	exported2 "github.com/pokt-network/pocket-core/x/apps/exported"
 	appsType "github.com/pokt-network/pocket-core/x/apps/types"
 	"github.com/pokt-network/pocket-core/x/nodes/exported"
 	nodesTypes "github.com/pokt-network/pocket-core/x/nodes/types"
@@ -331,7 +328,7 @@ type MockPosKeeper struct {
 type MockPocketKeeper struct{}
 
 func (m MockPocketKeeper) Codec() *codec.Codec {
-	return makeTestCodec()
+	panic("implement me")
 }
 
 func (m MockPocketKeeper) SessionNodeCount(ctx sdk.Ctx) (res int64) {
@@ -395,13 +392,4 @@ func (m MockPosKeeper) BlocksPerSession(ctx sdk.Ctx) (res int64) {
 
 func (m MockPosKeeper) StakeDenom(ctx sdk.Ctx) (res string) {
 	panic("implement me")
-}
-
-func makeTestCodec() *codec.Codec {
-	var cdc = codec.NewCodec(types2.NewInterfaceRegistry())
-	auth.RegisterCodec(cdc)
-	gov.RegisterCodec(cdc)
-	sdk.RegisterCodec(cdc)
-	crypto.RegisterAmino(cdc.AminoCodec().Amino)
-	return cdc
 }


### PR DESCRIPTION
This is a fix for a consensus failure with `wrong Block.Header.AppHash`, which is probably the same issue as #1478.

### Issue description:

For a node to be selected for a session, it must be valid not only at the start of a session but also at the end of a session.  If a node is edit-staked, jailed, or unjailed in the middle of a session, a servicer set of the session is changed.

When a node serves relays, on the other hand, it stores session information into the global session cache.  If the session's servicer set is changed, the node needs to update the cached session.  Otherwise the node accepts a claim that should be rejected, or rejects a claim that should be accepted.  As a result, the node ends up with a consensus failure with `wrong Block.Header.AppHash`.

### Root cause and Fix:

The root cause is simple.  We have a call to `ClearSessionCache` in `EditStakeValidator`, `LegacyForceValidatorUnstake`, `ForceValidatorUnstake`, and `JailValidator`, but not in `UnjailValidator`.  The proposed fix is to add the call in `UnjailValidator` as well.