### PR TITLE
Fix TestValidatorStateChange_EditAndValidateStakeValidator

### DIFF
--- a/x/nodes/keeper/valStateChanges_test.go
+++ b/x/nodes/keeper/valStateChanges_test.go
@@ -210,6 +210,9 @@ func TestValidatorStateChange_EditAndValidateStakeValidator(t *testing.T) {
 			tt.want.Status = sdk.Staked
 			// see if the changes stuck
 			got, _ := keeper.GetValidator(context, tt.origApp.Address)
+			assert.Nil(t, got.OutputAddress, "OutputAddress was set before NCUST update")
+			// Manually updated `got` to account for post NCUST updates
+			got.OutputAddress = tt.want.OutputAddress
 			if !got.Equals(tt.want) {
 				t.Fatalf("Got app %s\nWanted app %s", got.String(), tt.want.String())
 			}


### PR DESCRIPTION
The test `TestValidatorStateChange_EditAndValidateStakeValidator` failed because `got.OutputAddress` was `nil` but `tt.want.OutputAddress` had a valid address.  Since this test is to test the behavior before NCUST, we make sure the fetched output address is nil and the rest of fields are the same as `tt.want`.

The behavior after NCUST is tested through the test `TestValidatorStateChange_EditAndValidateStakeValidatorAfterNonCustodialUpgrade`, which passes without failures.