### PR TITLE
Update the `TestApplication_CalculateAppRelays` test

### DIFF
--- a/x/apps/keeper/application.go
+++ b/x/apps/keeper/application.go
@@ -1,12 +1,13 @@
 package keeper
 
 import (
-	sdk "github.com/pokt-network/pocket-core/types"
-	"github.com/pokt-network/pocket-core/x/apps/exported"
-	"github.com/pokt-network/pocket-core/x/apps/types"
 	"math"
 	"math/big"
 	"os"
+
+	sdk "github.com/pokt-network/pocket-core/types"
+	"github.com/pokt-network/pocket-core/x/apps/exported"
+	"github.com/pokt-network/pocket-core/x/apps/types"
 )
 
 // GetApplication - Retrieve a single application from the main store

--- a/x/apps/keeper/application_test.go
+++ b/x/apps/keeper/application_test.go
@@ -74,7 +74,7 @@ func TestApplication_CalculateAppRelays(t *testing.T) {
 			wantSessionRelays:   sdk.NewInt(185695833),
 		},
 		{
-			testName:            "Calculate App relays - standard app w/ params at height=90074",
+			testName:            "Calculate App relays - standard app for 3 chains w/ params at height=90074",
 			appStake:            sdk.NewInt(1000000000), // 1000 POKT
 			appChains:           []string{"0021", "0022", "0023"},
 			stabilityAdjustment: 0,
@@ -83,6 +83,17 @@ func TestApplication_CalculateAppRelays(t *testing.T) {
 			sessionNodeCount:    24,
 			wantAppRelays:       sdk.NewInt(2000000),
 			wantSessionRelays:   sdk.NewInt(27778),
+		},
+		{
+			testName:            "Calculate App relays - standard app for 1 chain w/ params at height=90074",
+			appStake:            sdk.NewInt(1000000000), // 1000 POKT
+			appChains:           []string{"0021"},
+			stabilityAdjustment: 0,
+			baseRelaysPerPOKT:   200000,
+			participationRateOn: false,
+			sessionNodeCount:    24,
+			wantAppRelays:       sdk.NewInt(2000000),
+			wantSessionRelays:   sdk.NewInt(83333),
 		},
 	}
 	for _, tt := range tests {

--- a/x/apps/keeper/application_test.go
+++ b/x/apps/keeper/application_test.go
@@ -64,7 +64,7 @@ func TestApplication_CalculateAppRelays(t *testing.T) {
 		},
 		{
 			testName:            "Calculate App relays - param values at height=90074",
-			appStake:            sdk.NewInt(2228350000000),
+			appStake:            sdk.NewInt(2228350000000), // maximum app stake found
 			appChains:           []string{"0021"},
 			stabilityAdjustment: 0,
 			baseRelaysPerPOKT:   200000,

--- a/x/apps/keeper/application_test.go
+++ b/x/apps/keeper/application_test.go
@@ -63,8 +63,8 @@ func TestApplication_CalculateAppRelays(t *testing.T) {
 			wantSessionRelays: sdk.NewInt(100000),
 		},
 		{
-			testName:            "Calculate App relays - param values at height=90074",
-			appStake:            sdk.NewInt(2228350000000), // maximum app stake found
+			testName:            "Calculate App relays - max app w/ params at height=90074",
+			appStake:            sdk.NewInt(2228350000000), // maximum app stake found; 2228350 POKT
 			appChains:           []string{"0021"},
 			stabilityAdjustment: 0,
 			baseRelaysPerPOKT:   200000,
@@ -72,6 +72,17 @@ func TestApplication_CalculateAppRelays(t *testing.T) {
 			sessionNodeCount:    24,
 			wantAppRelays:       sdk.NewInt(4456700000),
 			wantSessionRelays:   sdk.NewInt(185695833),
+		},
+		{
+			testName:            "Calculate App relays - standard app w/ params at height=90074",
+			appStake:            sdk.NewInt(1000000000), // 1000 POKT
+			appChains:           []string{"0021", "0022", "0023"},
+			stabilityAdjustment: 0,
+			baseRelaysPerPOKT:   200000,
+			participationRateOn: false,
+			sessionNodeCount:    24,
+			wantAppRelays:       sdk.NewInt(2000000),
+			wantSessionRelays:   sdk.NewInt(27778),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
This test is a followup to an offline discussion related to how application relays are computed.

## Changes
Updating `TestApplication_CalculateAppRelays` to reflect:
- Maximum relays for the max staked application for ETH at height= 90074 on mainnet

<img width="720" alt="Screenshot 2023-03-29 at 7 32 47 PM" src="https://user-images.githubusercontent.com/1892194/228713192-45e29787-7f2a-4258-bfda-599e19ddf071.png">


## Context 
* [CalculateAppRelays](https://github.com/pokt-network/pocket-core/blob/5e5962bb3a645c2fe037b6b27e602c3cc06a128f/x/apps/keeper/application.go#L144) - Returns the maximum MaxRelays param stored in the app state used to determine MaxAppRelays at the start of every session
* [MaxAppRelays](https://github.com/pokt-network/pocket-core/blob/5e5962bb3a645c2fe037b6b27e602c3cc06a128f/x/pocketcore/types/session.go#L269) - Returns the maximum relays to serve an app in a session based on its apps and the number of nodes 

## Helpers

export POCKET_ENDPOINT=https://<user>:<password>@<host>:<port>


### Listing all params

```bash
curl --data '{"height": 90074}' --location -X 'POST' -H 'Content-Type: application/json' "${POCKET_ENDPOINT}/v1/query/allParams" | jq
```

### Listing all app stakes in descending order

```bash
curl --data '{"height": 90074, "opts": {"per_page":3000 } }' --location -X 'POST' -H 'Content-Type: application/json' "${POCKET_ENDPOINT}/v1/query/apps" | jq -r '.result | map({staked_tokens: .staked_tokens | tonumber}) | sort_by(-.staked_tokens) | .[].staked_tokens'
```

![Screenshot 2023-03-30 at 11 27 38 AM](https://user-images.githubusercontent.com/1892194/228930468-3f8c9835-d307-42d4-b271-b865441cf573.png)

