### PR TITLE
fix: reviewpad configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,3 @@
+## Description
+
+reviewpad:summary

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -19,28 +19,7 @@ labels:
 # Define the list of workflows to be run by Reviewpad.
 # A workflow is a list of actions that will be executed based on the defined rules.
 # For more details see https://docs.reviewpad.com/guides/syntax#workflow.
-# workflows:
-#   # This workflow calls Reviewpad AI agent to summarize the pull request.
-#   - name: summarize
-#     description: Summarize the pull request
-#     always-run: true
-#     if:
-#       # Summarize the pull requests when pull requests are opened or synchronized.
-#       - rule: ($eventType() == "synchronize" || $eventType() == "opened") && $state() == "open"
-#         extra-actions:
-#           - $summarize()
-
-  # This workflow assigns the most relevant reviewer to pull requests.
-  # This helps guarantee that pull requests are reviewed by at least one person.
-#   - name: reviewer-assignment
-#     description: Assign the most relevant reviewer to pull requests
-#     always-run: true
-#     if:
-#       # Automatically assign reviewer when the pull request is ready for review.
-#       - rule: $isDraft() == false
-#         extra-actions:
-#           - $assignCodeAuthorReviewers()
-
+workflows:
   # This workflow praises contributors on their pull request contributions.
   # This helps contributors feel appreciated.
   - name: praise-contributors-on-milestones


### PR DESCRIPTION
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 May 23 13:34 UTC
This pull request includes a new PULL_REQUEST_TEMPLATE and updates the reviewpad.yml file, removing the workflows section and leaving only the "praise-contributors-on-milestones" workflow.
<!-- reviewpad:summarize:end -->

We understand the the automatic summarization feature was spammy. So now you can use it through markers so that it directly updates the PR description.