### PR TITLE
[Do not merge yet] Upgrade app version from 0.9.2 to 0.10.0

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	AppVersion = "RC-0.9.2"
+	AppVersion = "RC-0.10.0"
 )
 
 // NewPocketCoreApp is a constructor function for PocketCoreApp

--- a/doc/guides/quickstart.md
+++ b/doc/guides/quickstart.md
@@ -70,8 +70,26 @@ pocket version
 
 ### From Homebrew
 
-```text
+To install `pocket` via `homebrew`
+
+```bash
 brew tap pokt-network/pocket-core && brew install pokt-network/pocket-core/pocket
+```
+
+To update via `homebrew`
+
+```bash
+ brew upgrade pokt-network/pocket-core/pocket
+```
+
+The version of `pocket` maintained by the `brew tap` can be found in [pokt-network/homebrew-pocket-core](https://github.com/pokt-network/homebrew-pocket-core).
+
+### From Tea
+
+Pocket was added to tea.xyz, a new package manager from the creator of homebrew in [this PR](https://github.com/teaxyz/pantry/pull/862)
+
+```bash
+tea pocket
 ```
 
 #### Test installation


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 May 23 23:21 UTC
This pull request upgrades the `brew/tap` from version `0.9.2` to `0.10.0` for the `pocket` application. It also updates the version number in the `AppVersion` constant in `app/app.go`. Additionally, it includes instructions for updating the application using `homebrew` and installing or updating the application using `tea`.
<!-- reviewpad:summarize:end -->
