### PR TITLE
Improve version string comparison

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	dbm "github.com/tendermint/tm-db"
@@ -153,4 +154,46 @@ func ContainsString(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func CompareVersionStrings(verStr1, verStr2 string) (int, error) {
+	ver1 := strings.Split(verStr1, ".")
+	ver2 := strings.Split(verStr2, ".")
+	lenVer1 := len(ver1)
+	lenVer2 := len(ver2)
+
+	numChunks := lenVer1
+	if lenVer2 < numChunks {
+		numChunks = lenVer2
+	}
+
+	for i := 0; i < numChunks; i++ {
+		verNum1, err := strconv.Atoi(ver1[i])
+		if err != nil {
+			return 0, err
+		}
+
+		verNum2, err := strconv.Atoi(ver2[i])
+		if err != nil {
+			return 0, err
+		}
+
+		if verNum1 < verNum2 {
+			return -1, nil
+		}
+
+		if verNum1 > verNum2 {
+			return 1, nil
+		}
+	}
+
+	if lenVer2 > numChunks {
+		return -1, nil
+	}
+
+	if lenVer1 > numChunks {
+		return 1, nil
+	}
+
+	return 0, nil
 }

--- a/types/utils.go
+++ b/types/utils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 	"log"
 	"regexp"
 	"runtime"
@@ -13,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/syndtr/goleveldb/leveldb/opt"
 	dbm "github.com/tendermint/tm-db"
 )
 
@@ -156,6 +156,13 @@ func ContainsString(s []string, e string) bool {
 	return false
 }
 
+// Compares two version strings, which are expected to be dot-delimited
+// integers like "1.2.3.4".  The result is similar to strcmp in C, negative
+// if the first version string is considered to be earlier, positive if the
+// second version string is considered to be earlier, and zero if both version
+// strings are the same.  If any of the given version strings is not
+// dot-delimited, the function returns an error.
+// For more details, see Test_CompareVersionStrings in utils_test.go.
 func CompareVersionStrings(verStr1, verStr2 string) (int, error) {
 	ver1 := strings.Split(verStr1, ".")
 	ver2 := strings.Split(verStr2, ".")

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +64,27 @@ func TestTimeFormatAndParse(t *testing.T) {
 		require.True(t, timeFromRFC.Equal(timeFromSDKFormat))
 		require.Equal(t, timeFromRFC.Format(SortableTimeFormat), tc.SDKSortableTimeStr)
 	}
+}
+func Test_compareVersionStrings(t *testing.T) {
+	comp, err := CompareVersionStrings("0.9.1.1", "0.10.0")
+	assert.Nil(t, err)
+	assert.Equal(t, comp, -1)
+
+	comp, err = CompareVersionStrings("1.0", "0.9.9")
+	assert.Nil(t, err)
+	assert.Equal(t, comp, 1)
+
+	comp, err = CompareVersionStrings("0.0.0.1", "0.0.0.1")
+	assert.Nil(t, err)
+	assert.Equal(t, comp, 0)
+
+	comp, err = CompareVersionStrings("0.0.0.1.0", "0.0.0.1")
+	assert.Nil(t, err)
+	assert.Equal(t, comp, 1)
+
+	comp, err = CompareVersionStrings("v0.9.1.1", "0.10.0")
+	assert.NotNil(t, err)
+
+	comp, err = CompareVersionStrings("", "1")
+	assert.NotNil(t, err)
 }

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -65,10 +65,14 @@ func TestTimeFormatAndParse(t *testing.T) {
 		require.Equal(t, timeFromRFC.Format(SortableTimeFormat), tc.SDKSortableTimeStr)
 	}
 }
-func Test_compareVersionStrings(t *testing.T) {
+func Test_CompareVersionStrings(t *testing.T) {
 	comp, err := CompareVersionStrings("0.9.1.1", "0.10.0")
 	assert.Nil(t, err)
 	assert.Equal(t, comp, -1)
+
+	comp, err = CompareVersionStrings("0.10.0", "0.9.2")
+	assert.Nil(t, err)
+	assert.Equal(t, comp, 1)
 
 	comp, err = CompareVersionStrings("1.0", "0.9.9")
 	assert.Nil(t, err)


### PR DESCRIPTION
This patch changes the logic to compare the version strings to see if the network has been upgraded or not.  The simple string comparison does not work when the network is upgraded from "0.9" to "0.10".  The proposed fix is to convert a version string into a slice of integers before comparison.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 00:08 UTC
This pull request includes two patches. 
The first patch improves the version string comparison in `types/utils.go` by adding a new function called `CompareVersionStrings`. This function compares two version strings as if they are integers and returns negative, positive, or zero if the first string is earlier, later, or equal to the second string respectively. It also includes a new unit test for the function.
The second patch addresses some of the previous comments and adds a new test case for the `CompareVersionStrings` function.
<!-- reviewpad:summarize:end -->
