### PR TITLE
[CI/Containers] Add image build workflow

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,18 @@
+# Based on a previous implementation to make sure we don't break existing deployments.
+# https://github.com/pokt-network/pocket-core-deployments/blob/staging/docker/Dockerfile
+
+FROM golang:1.17-alpine as build
+RUN apk add --no-cache ca-certificates
+WORKDIR /build
+ADD . .
+RUN go build -o pocket app/cmd/pocket_core/main.go
+
+FROM alpine
+RUN apk add --update --no-cache expect bash leveldb-dev tzdata && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
+    && addgroup --gid 1001 -S app \
+    && adduser --uid 1005 -S -G app app
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /build/pocket /bin/pocket
+COPY .github/workflows/entrypoint.sh /home/app/entrypoint.sh
+RUN chown -R app /bin/pocket && mkdir -p /home/app/.pocket/config && chown -R app /home/app/.pocket
+ENTRYPOINT ["/usr/bin/expect", "/home/app/entrypoint.sh"]

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -6,9 +6,9 @@ name: Build and push images
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [staging]
   pull_request:
-    branches: [main]
+    branches: [staging]
   release:
     types: [published]
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,53 @@
+# This workflow only handles build & push of images to GitHub Container Registry.
+# We have other pipepines in CircleCI, such as tests, that are not migrated to GitHub Actions.
+
+name: Build and push images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: "true"
+        with:
+          images: |
+            ghcr.io/pokt-network/pocket-v0
+          tags: |
+            type=schedule
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          file: .github/workflows/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/expect
+
+# Send `pocket stop` when interrupted to prevent corruption
+proc graceful_exit {} {
+    send_user "Gracefully exiting Pocket...\n"
+    spawn sh -c "pocket stop"
+}
+
+trap graceful_exit {SIGINT SIGTERM}
+
+# Command to run
+set command $argv
+set timeout -1
+
+# Create work dir
+spawn sh -c "mkdir -p /home/app/.pocket/config"
+expect eof
+
+# Pull variables from env if set
+set genesis ""
+catch {set genesis $env(POCKET_CORE_GENESIS)}
+
+set chains ""
+catch {set chains $env(POCKET_CORE_CHAINS)}
+
+set config ""
+catch {set config $env(POCKET_CORE_CONFIG)}
+
+# Create dynamic config files
+if {$genesis != ""} {
+    set genesis_file [open /home/app/.pocket/config/genesis.json w]
+    puts $genesis_file $genesis
+    close $genesis_file
+    send_user "GENESIS loaded from env\n"
+}
+if {$chains != ""} {
+    set chains_file [open /home/app/.pocket/config/chains.json w]
+    puts $chains_file $chains
+    close $chains_file
+    send_user "CHAINS loaded from env\n"
+}
+if {$config != ""} {
+    set config_file [open /home/app/.pocket/config/config.json w]
+    puts $config_file $config
+    close $config_file
+    send_user "CONFIG loaded from env\n"
+}
+
+# If key isn't passed in, start the node
+if { $env(POCKET_CORE_KEY) eq "" }  {
+    log_user 0
+    spawn sh -c "$command"
+    send -- "$env(POCKET_CORE_PASSPHRASE)\n"
+    log_user 1
+} else {
+# If key is passed in, load it into the local accounts
+    log_user 0
+    spawn pocket accounts import-raw $env(POCKET_CORE_KEY)
+    sleep 1
+    send -- "$env(POCKET_CORE_PASSPHRASE)\n"
+    expect eof
+    spawn sh -c "pocket accounts set-validator `pocket accounts list | cut -d' ' -f2- `"
+    sleep 1
+    send -- "$env(POCKET_CORE_PASSPHRASE)\n"
+    expect eof
+    log_user 1
+    spawn sh -c "$command"
+}
+
+expect eof
+exit


### PR DESCRIPTION
## Description

With our decision to switch to GitHub Packages as the Container Registry for v0, it becomes easier to use the workflow to push the image.

To ensure a seamless transition, I have used an existing multi-arch build as a base. This means that existing deployments should not be affected or break due to the changes.

To validate the compatibility, I conducted tests on my own node by replacing the `poktnetwork/pocket-core:RC-0.9.2` image with the one generated by this workflow. The tests indicated that everything functioned as expected, without any issues.

Registry link: https://github.com/pokt-network/pocket-core/pkgs/container/pocket-v0

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jun 23 22:17 UTC
This pull request adds an image build workflow, with a Dockerfile, build-images.yaml, and entrypoint.sh. The workflow handles build and push of images to GitHub Container Registry, while staging is set as the main branch. Additionally, the patch checks if it works with PR events.
<!-- reviewpad:summarize:end -->
