### PR TITLE
Update default session sync allowance

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -84,7 +84,7 @@ const (
 	DefaultMaxEvidenceCacheEntries     = 500
 	DefaultListenAddr                  = "tcp://0.0.0.0:"
 	DefaultClientBlockSyncAllowance    = 10
-	DefaultSessionSyncAllowance        = 1 // 1 session (irrespective of num blocks per session)
+	DefaultSessionSyncAllowance        = 0 // This config represents a session unit (irrespective of num blocks per session)
 	DefaultJSONSortRelayResponses      = true
 	DefaultTxIndexer                   = "kv"
 	DefaultRPCDisableTransactionEvents = true


### PR DESCRIPTION
## Description
This PR sets the default session sync allowance back to zero, effectively removing the session rollover fix as a default setting. Clients can re-enable as they see fit. Gateways should code logic that accounts for old sessions. Gateways should also always use the latest session when possible.

PNI recently transitioned from AWS to GCP, and their Portal V1 stack to V2 stack. This has resulted in 1.3B to ~600m relays being submitted on the chain. Our fleet of 4K+ nodes has also seen reduced served traffic significantly.

The rationale behind this change is simple: Too many changes all happening at once. This change is simply to prevent additional noise from the ongoing incident. Once PNI's V2 gateway is stable and network traffic is stable, we can set this default back to `1` with a new build given its nonconsensus changing.

NOTE:  This is to prevent any more damage with the ongoing incident and cause additional confusion for the gateway and node runners. Since we don't know what the root cause is for the missing traffic, by not including it by default, it removes one less factor for them to consider.

Relevant PR: https://github.com/pokt-network/pocket-core/pull/1536

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jun 23 04:41 UTC
This pull request updates the default session sync allowance configuration from 1 to 0, representing a session unit (irrespective of num blocks per session). This ensures that the session sync allowance configuration is more adjustable for user's needs.
<!-- reviewpad:summarize:end -->
