### PR TITLE
Revert Mainnet genesis file changes from #1535

### DIFF
--- a/app/genesis.go
+++ b/app/genesis.go
@@ -8754,7 +8754,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "4900000000000",
-                    "service_url": "https://node1.dev.poktnodes.com:443",
+                    "service_url": "https://node1.poktnodes.com:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -8767,7 +8767,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "4900000000000",
-                    "service_url": "https://node2.dev.poktnodes.com:443",
+                    "service_url": "https://node2.poktnodes.com:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -8780,7 +8780,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "200000000000",
-                    "service_url": "https://node3.dev.poktnodes.com:443",
+                    "service_url": "https://node3.poktnodes.com:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -12121,7 +12121,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "152527740000",
-                    "service_url": "https://node3.dev.pokt.net:443",
+                    "service_url": "https://node1.pokt.net:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -12134,7 +12134,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "148041630000",
-                    "service_url": "https://node2.dev.pokt.net:443",
+                    "service_url": "https://node2.pokt.net:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -12147,7 +12147,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "148041630000",
-                    "service_url": "https://node3.dev.pokt.net:4433",
+                    "service_url": "https://node3.pokt.net:4433",
                     "chains": [
                         "0001",
                         "0021"
@@ -14799,7 +14799,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "18083175000000",
-                    "service_url": "https://node3.dev.pokt.foundation:443",
+                    "service_url": "https://node1.pokt.foundation:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -14812,7 +14812,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "18083175000000",
-                    "service_url": "https://node2.dev.pokt.foundation:443",
+                    "service_url": "https://node2.pokt.foundation:443",
                     "chains": [
                         "0001",
                         "0021"
@@ -14825,7 +14825,7 @@ var mainnetGenesis = `{
                     "jailed": true,
                     "status": 2,
                     "tokens": "18631150000000",
-                    "service_url": "https://node3.dev.pokt.foundation:443",
+                    "service_url": "https://node3.pokt.foundation:443",
                     "chains": [
                         "0001",
                         "0021"


### PR DESCRIPTION
## Description

The mainnet genesis file was changed as part of PR https://github.com/pokt-network/pocket-core/pull/1535 when adding misc changes for localnet. Since I believe the genesis file is generated anded loaded via `InitGenesis`  and `InitChainer`, this resulted in a different genesis from the rest of the network and ultimately a different generated app hash than what the other peers are synced to. As a result, this caused syncing issues when trying to produce the first block and onwards as reported in https://github.com/pokt-network/pocket-core/issues/1564.

This change reverts the changes made in the genesis json in #1535

Tested by applying this change and running 
```sh
pocket start --seeds="7c0d7ec36db6594c1ffaa99724e1f8300bbd52d0@seed1.mainnet.pokt.network:26662,cdcf936d70726dd724e0e6a8353d8e5ba5abdd20@seed2.mainnet.pokt.network:26663,74b4322a91c4a7f3e774648d0730c1e610494691@seed3.mainnet.pokt.network:26662,b3235089ff302c9615ba661e13e601d9d6265b15@seed4.mainnet.pokt.network:26663" --mainnet
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 07:43 UTC
This pull request reverts the mainnet genesis file from #1535. It updates the service URLs for several nodes in the mainnetGenesis variable in the genesis.go file. The URLs are changed from the dev environment to the production environment for the poktnodes.com and pokt.net domains. Additionally, the URLs for the pokt.foundation domain are updated as well.
<!-- reviewpad:summarize:end -->
