### PR TITLE
Change default config file values

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -166,8 +166,10 @@ func DefaultConfig(dataDir string) Config {
 	c.TendermintConfig.DBBackend = string(db.GoLevelDBBackend)
 	c.TendermintConfig.RPC.GRPCMaxOpenConnections = 2500
 	c.TendermintConfig.RPC.MaxOpenConnections = 2500
-	c.TendermintConfig.Mempool.Size = 9000
-	c.TendermintConfig.Mempool.CacheSize = 9000
+	c.TendermintConfig.Mempool.Size = 18000
+	c.TendermintConfig.Mempool.CacheSize = 18000
+	c.TendermintConfig.Mempool.MaxTxsBytes = 2147483648
+	c.TendermintConfig.Mempool.MaxTxBytes = 2097152
 	c.TendermintConfig.FastSync = &config.FastSyncConfig{
 		Version: "v1",
 	}


### PR DESCRIPTION
## Description

Changes default values for the config file.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Jul 23 23:19 UTC
This pull request changes the default values in the `config.go` file. Specifically, it increases the values for `Mempool.Size` and `Mempool.CacheSize` from 9000 to 18000. Additionally, it adds two new fields `Mempool.MaxTxsBytes` and `Mempool.MaxTxBytes` with their respective values. This patch also updates the `FastSync.Version` to "v1".
<!-- reviewpad:summarize:end -->
