### PR TITLE
Fix infinite recursion in Session.HashString

### DIFF
--- a/x/pocketcore/types/session.go
+++ b/x/pocketcore/types/session.go
@@ -4,10 +4,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
+
 	sdk "github.com/pokt-network/pocket-core/types"
 	appexported "github.com/pokt-network/pocket-core/x/apps/exported"
 	"github.com/pokt-network/pocket-core/x/nodes/exported"
-	"log"
 )
 
 // "Session" - The relationship between an application and the pocket network
@@ -17,7 +18,7 @@ func (s Session) IsSealable() bool {
 }
 
 func (s Session) HashString() string {
-	return s.HashString()
+	return s.SessionHeader.HashString()
 }
 
 // "NewSession" - create a new session from seed data
@@ -110,11 +111,11 @@ func NewSessionNodes(sessionCtx, ctx sdk.Ctx, keeper PosKeeper, chain string, se
 	}
 	sessionNodes = make(SessionNodes, sessionNodesCount)
 	var node exported.ValidatorI
-	//unique address map to avoid re-checking a pseudorandomly selected servicer
+	// unique address map to avoid re-checking a pseudorandomly selected servicer
 	m := make(map[string]struct{})
 	// only select the nodesAddrs if not jailed
 	for i, numOfNodes := 0, 0; ; i++ {
-		//if this is true we already checked all nodes we got on getValidatorsBychain
+		// if this is true we already checked all nodes we got on getValidatorsBychain
 		if len(m) >= totalNodes {
 			return nil, NewInsufficientNodesError(ModuleName)
 		}
@@ -124,11 +125,11 @@ func NewSessionNodes(sessionCtx, ctx sdk.Ctx, keeper PosKeeper, chain string, se
 		sessionKey = Hash(sessionKey)
 		// get the node from the array
 		n := nodesAddrs[index.Int64()]
-		//if we already have seen this address we continue as it's either on the list or discarded
+		// if we already have seen this address we continue as it's either on the list or discarded
 		if _, ok := m[n.String()]; ok {
 			continue
 		}
-		//add the node address to the map
+		// add the node address to the map
 		m[n.String()] = struct{}{}
 
 		// cross check the node from the `new` or `end` world state
@@ -267,8 +268,8 @@ func BlockHash(ctx sdk.Context) string {
 
 // "MaxPossibleRelays" - Returns the maximum possible amount of relays for an App on a sessions
 func MaxPossibleRelays(app appexported.ApplicationI, sessionNodeCount int64) sdk.BigInt {
-	//GetMaxRelays Max value is bound to math.MaxUint64,
-	//current worse case is 1 chain and 5 nodes per session with a result of 3689348814741910323 which can be used safely as int64
+	// GetMaxRelays Max value is bound to math.MaxUint64,
+	// current worse case is 1 chain and 5 nodes per session with a result of 3689348814741910323 which can be used safely as int64
 	return app.GetMaxRelays().ToDec().Quo(sdk.NewDec(int64(len(app.GetChains())))).Quo(sdk.NewDec(sessionNodeCount)).RoundInt()
 }
 


### PR DESCRIPTION
## Description

Fixes #1578 

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Sep 23 07:14 UTC
This pull request fixes an issue with infinite recursion in the `HashString` method of the `Session` struct. The patch adds a fix to the method by returning `s.SessionHeader.HashString()` instead of calling `s.HashString()` recursively. Additionally, there are some code formatting changes and comments added for clarification.
<!-- reviewpad:summarize:end -->
