### PR TITLE
Allow an AppMsgStake tx to change the address of a staked app

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -88,6 +88,7 @@ func NewPocketCoreApp(genState GenesisState, keybase keys.Keybase, tmClient clie
 	app.nodesKeeper.PocketKeeper = app.pocketKeeper
 	app.appsKeeper.PocketKeeper = app.pocketKeeper
 	app.accountKeeper.POSKeeper = app.nodesKeeper
+	app.accountKeeper.AppKeeper = app.appsKeeper
 	// setup module manager
 	app.mm = module.NewManager(
 		auth.NewAppModule(app.accountKeeper),

--- a/app/cmd/cli/app.go
+++ b/app/cmd/cli/app.go
@@ -121,7 +121,7 @@ var appTransferCmd = &cobra.Command{
 	Use:   "transfer <fromAddr> <newAppPubKey> <networkID> <fee> [memo]",
 	Short: "Transfer the ownership of a staked app from one to another",
 	Long: `Submits a transaction to transfer the ownership of a staked app from
-<fromAddr> to a neww account specified as <newAppPubKey> without unstaking
+<fromAddr> to a new account specified as <newAppPubKey> without unstaking
 any app.  In other words, this edits the address of a staked app.  To run this
 command, you must have the private key of the current staked app <fromAddr>
 `,

--- a/app/cmd/cli/app.go
+++ b/app/cmd/cli/app.go
@@ -19,6 +19,7 @@ func init() {
 	rootCmd.AddCommand(appCmd)
 	appCmd.AddCommand(appStakeCmd)
 	appCmd.AddCommand(appUnstakeCmd)
+	appCmd.AddCommand(appTransferCmd)
 	appCmd.AddCommand(createAATCmd)
 }
 
@@ -112,6 +113,65 @@ Prompts the user for the <fromAddr> account passphrase.`,
 			fmt.Println(err)
 			return
 		}
+		fmt.Println(resp)
+	},
+}
+
+var appTransferCmd = &cobra.Command{
+	Use:   "transfer <fromAddr> <newAppPubKey> <networkID> <fee> [memo]",
+	Short: "Transfer the ownership of a staked app from one to another",
+	Long: `Submits a transaction to transfer the ownership of a staked app from
+<fromAddr> to a neww account specified as <newAppPubKey> without unstaking
+any app.  In other words, this edits the address of a staked app.  To run this
+command, you must have the private key of the current staked app <fromAddr>
+`,
+	Args: cobra.MinimumNArgs(4),
+	Run: func(cmd *cobra.Command, args []string) {
+		app.InitConfig(datadir, tmNode, persistentPeers, seeds, remoteCLIURL)
+
+		currentAppAddr := args[0]
+		newAppPubKey := args[1]
+		networkId := args[2]
+		feeStr := args[3]
+		memo := ""
+		if len(args) >= 5 {
+			memo = args[4]
+		}
+
+		fee, err := strconv.ParseInt(feeStr, 10, 64)
+		if err != nil {
+			fmt.Println("Invalid fee:", err)
+			return
+		}
+
+		fmt.Printf("Enter passphrase to unlock %s: ", currentAppAddr)
+		passphrase := app.Credentials(pwd)
+
+		rawTx, err := TransferApp(
+			currentAppAddr,
+			newAppPubKey,
+			passphrase,
+			networkId,
+			fee,
+			memo,
+		)
+		if err != nil {
+			fmt.Println("Failed to build a transaction:", err)
+			return
+		}
+
+		rawTxBytes, err := json.Marshal(rawTx)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		resp, err := QueryRPC(SendRawTxPath, rawTxBytes)
+		if err != nil {
+			fmt.Println("Failed to submit a transaction:", err)
+			return
+		}
+
 		fmt.Println(resp)
 	},
 }

--- a/app/cmd/cli/txUtil.go
+++ b/app/cmd/cli/txUtil.go
@@ -397,6 +397,52 @@ func UnstakeApp(fromAddr, passphrase, chainID string, fees int64, legacyCodec bo
 	}, nil
 }
 
+func TransferApp(
+	currentAppAddrStr, newAppPubKeyStr, passphrase, networkId string,
+	fee int64,
+	memo string,
+) (*rpc.SendRawTxParams, error) {
+	currentAppAddr, err := sdk.AddressFromHex(currentAppAddrStr)
+	if err != nil {
+		return nil, err
+	}
+
+	newAppPubKey, err := crypto.NewPublicKey(newAppPubKeyStr)
+	if err != nil {
+		return nil, err
+	}
+
+	keybase, err := app.GetKeybase()
+	if err != nil {
+		return nil, err
+	}
+
+	msg := appsType.MsgStake{PubKey: newAppPubKey}
+	if err = msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	txBz, err := newTxBz(
+		app.Codec(),
+		&msg,
+		currentAppAddr,
+		networkId,
+		keybase,
+		passphrase,
+		fee,
+		memo,
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rpc.SendRawTxParams{
+		Addr:        currentAppAddrStr,
+		RawHexBytes: hex.EncodeToString(txBz),
+	}, nil
+}
+
 func DAOTx(fromAddr, toAddr, passphrase string, amount sdk.BigInt, action, chainID string, fees int64, legacyCodec bool) (*rpc.SendRawTxParams, error) {
 	fa, err := sdk.AddressFromHex(fromAddr)
 	if err != nil {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1,10 +1,10 @@
-///*
-//Package baseapp contains data structures that provide basic data storage
-//functionality and act as a bridge between the ABCI interface and the SDK
-//abstractions.
+// /*
+// Package baseapp contains data structures that provide basic data storage
+// functionality and act as a bridge between the ABCI interface and the SDK
+// abstractions.
 //
-//BaseApp has no state except the CommitMultiStore you provide upon init.
-//*/
+// BaseApp has no state except the CommitMultiStore you provide upon init.
+// */
 package baseapp
 
 import (
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"github.com/pokt-network/pocket-core/codec/types"
 	"github.com/pokt-network/pocket-core/crypto"
-	types2 "github.com/pokt-network/pocket-core/x/apps/types"
 	"github.com/pokt-network/pocket-core/x/auth"
 	"github.com/tendermint/tendermint/evidence"
 	"github.com/tendermint/tendermint/node"
@@ -810,9 +809,8 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 		msg := tx.GetMsg()
 		messageType = msg.Type()
 		recipient = msg.GetRecipient()
-		if signerPK == nil || messageType == types2.MsgAppStakeName {
-			signers := msg.GetSigners()
-			if len(signers) >= 1 {
+		if signerPK == nil {
+			if signers := msg.GetSigners(); len(signers) >= 1 {
 				signer = signers[0]
 			}
 		} else {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -58,6 +58,7 @@ const (
 	OutputAddressEditKey         = "OEDIT"
 	ClearUnjailedValSessionKey   = "CRVAL"
 	PerChainRTTM                 = "PerChainRTTM"
+	AppTransferKey               = "AppTransfer"
 )
 
 func GetCodecUpgradeHeight() int64 {
@@ -283,6 +284,12 @@ func (cdc *Codec) IsAfterOutputAddressEditorUpgrade(height int64) bool {
 func (cdc *Codec) IsAfterPerChainRTTMUpgrade(height int64) bool {
 	return (UpgradeFeatureMap[PerChainRTTM] != 0 &&
 		height >= UpgradeFeatureMap[PerChainRTTM]) ||
+		TestMode <= -3
+}
+
+func (cdc *Codec) IsAfterAppTransferUpgrade(height int64) bool {
+	return (UpgradeFeatureMap[AppTransferKey] != 0 &&
+		height >= UpgradeFeatureMap[AppTransferKey]) ||
 		TestMode <= -3
 }
 

--- a/x/apps/keeper/appStateChanges_test.go
+++ b/x/apps/keeper/appStateChanges_test.go
@@ -407,7 +407,8 @@ func transferApp(
 	if err != nil {
 		return err
 	}
-	return k.TransferApplication(ctx, curApp, transferTo)
+	k.TransferApplication(ctx, curApp, transferTo)
+	return nil
 }
 
 func TestAppStateChange_Transfer(t *testing.T) {
@@ -423,6 +424,7 @@ func TestAppStateChange_Transfer(t *testing.T) {
 
 	ctx, _, keeper := createTestInput(t, true)
 
+	// Create four wallets and app-stake three of them
 	apps := make([]types.Application, 3)
 	pubKeys := make([]crypto.PublicKey, 4)
 	addrs := make([]sdk.Address, 4)
@@ -440,6 +442,7 @@ func TestAppStateChange_Transfer(t *testing.T) {
 	// apps[0]: staked
 	// apps[1]: unstaking
 	// apps[2]: staked and jailed
+	// apps[3]: not an application (see pubKeys[3]) and will be used for the transfer
 	keeper.BeginUnstakingApplication(ctx, apps[1])
 	keeper.JailApplication(ctx, apps[2].Address)
 

--- a/x/apps/keeper/appUtil.go
+++ b/x/apps/keeper/appUtil.go
@@ -31,6 +31,7 @@ func (k Keeper) AllApplications(ctx sdk.Ctx) (apps []exported.ApplicationI) {
 	return apps
 }
 
+// IsMsgAppTransfer - Returns if the given message is to transfer the ownership
 func (k Keeper) IsMsgAppTransfer(
 	ctx sdk.Ctx,
 	msgSigner sdk.Address,

--- a/x/apps/keeper/appUtil.go
+++ b/x/apps/keeper/appUtil.go
@@ -30,3 +30,33 @@ func (k Keeper) AllApplications(ctx sdk.Ctx) (apps []exported.ApplicationI) {
 	}
 	return apps
 }
+
+func (k Keeper) IsMsgAppTransfer(
+	ctx sdk.Ctx,
+	msgSigner sdk.Address,
+	msg sdk.Msg,
+) bool {
+	if !ctx.IsAfterUpgradeHeight() ||
+		!k.Cdc.IsAfterAppTransferUpgrade(ctx.BlockHeight()) {
+		return false
+	}
+
+	msgStake, ok := msg.(*types.MsgStake)
+	if !ok {
+		return false
+	}
+
+	if msgStake.IsValidTransfer() != nil {
+		return false
+	}
+
+	if msgSigner.Equals(sdk.Address(msgStake.PubKey.Address())) {
+		return false
+	}
+
+	if _, found := k.GetApplication(ctx, msgSigner); !found {
+		return false
+	}
+
+	return true
+}

--- a/x/apps/keeper/common_test.go
+++ b/x/apps/keeper/common_test.go
@@ -1,13 +1,19 @@
 package keeper
 
 import (
-	types2 "github.com/pokt-network/pocket-core/codec/types"
 	"math/rand"
 	"testing"
 
+	"github.com/pokt-network/pocket-core/codec"
+	types2 "github.com/pokt-network/pocket-core/codec/types"
 	"github.com/pokt-network/pocket-core/crypto"
+	"github.com/pokt-network/pocket-core/store"
+	sdk "github.com/pokt-network/pocket-core/types"
 	"github.com/pokt-network/pocket-core/types/module"
 	"github.com/pokt-network/pocket-core/x/apps/exported"
+	"github.com/pokt-network/pocket-core/x/apps/types"
+	"github.com/pokt-network/pocket-core/x/auth"
+	"github.com/pokt-network/pocket-core/x/gov"
 	govTypes "github.com/pokt-network/pocket-core/x/gov/types"
 	"github.com/pokt-network/pocket-core/x/nodes"
 	nodeskeeper "github.com/pokt-network/pocket-core/x/nodes/keeper"
@@ -17,13 +23,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
-
-	"github.com/pokt-network/pocket-core/codec"
-	"github.com/pokt-network/pocket-core/store"
-	sdk "github.com/pokt-network/pocket-core/types"
-	"github.com/pokt-network/pocket-core/x/apps/types"
-	"github.com/pokt-network/pocket-core/x/auth"
-	"github.com/pokt-network/pocket-core/x/gov"
 )
 
 // : deadcode unused
@@ -183,6 +182,13 @@ func getStakedApplication() types.Application {
 func getUnstakedApplication() types.Application {
 	v := getApplication()
 	return v.UpdateStatus(sdk.Unstaked)
+}
+
+func createNewApplication() types.Application {
+	v := getApplication()
+	v.StakedTokens = sdk.ZeroInt()
+	v.Status = sdk.Unstaked
+	return v
 }
 
 func getUnstakingApplication() types.Application {

--- a/x/apps/types/msg.go
+++ b/x/apps/types/msg.go
@@ -45,6 +45,8 @@ func (msg MsgStake) GetSignBytes() []byte {
 
 // ValidateBasic quick validity check for staking an application
 func (msg MsgStake) ValidateBasic() sdk.Error {
+	// App's MsgStake has a special case for transferring the ownership.
+	// We first check if the given message is that special case or not.
 	if err := msg.IsValidTransfer(); err == nil {
 		return nil
 	}
@@ -77,7 +79,7 @@ func (msg MsgStake) IsValidTransfer() sdk.Error {
 	}
 
 	// The chains must be empty for transfer
-	if !msg.Value.IsZero() {
+	if len(msg.Chains) > 0 {
 		return ErrTooManyChains(DefaultCodespace)
 	}
 

--- a/x/apps/types/msg.go
+++ b/x/apps/types/msg.go
@@ -2,8 +2,8 @@ package types
 
 import (
 	"fmt"
-	"github.com/pokt-network/pocket-core/codec"
 
+	"github.com/pokt-network/pocket-core/codec"
 	"github.com/pokt-network/pocket-core/crypto"
 	sdk "github.com/pokt-network/pocket-core/types"
 )
@@ -45,6 +45,10 @@ func (msg MsgStake) GetSignBytes() []byte {
 
 // ValidateBasic quick validity check for staking an application
 func (msg MsgStake) ValidateBasic() sdk.Error {
+	if err := msg.IsValidTransfer(); err == nil {
+		return nil
+	}
+
 	if msg.PubKey == nil || msg.PubKey.RawString() == "" {
 		return ErrNilApplicationAddr(DefaultCodespace)
 	}
@@ -59,6 +63,24 @@ func (msg MsgStake) ValidateBasic() sdk.Error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (msg MsgStake) IsValidTransfer() sdk.Error {
+	if msg.PubKey == nil {
+		return ErrNilApplicationAddr(DefaultCodespace)
+	}
+
+	// The stake amount must be zero for transfer
+	if !msg.Value.IsZero() {
+		return ErrBadStakeAmount(DefaultCodespace)
+	}
+
+	// The chains must be empty for transfer
+	if !msg.Value.IsZero() {
+		return ErrTooManyChains(DefaultCodespace)
+	}
+
 	return nil
 }
 
@@ -177,7 +199,7 @@ func (msg MsgBeginUnstake) GetFee() sdk.BigInt {
 	return sdk.NewInt(AppFeeMap[msg.Type()])
 }
 
-//----------------------------------------------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------------------------
 // Route provides router key for msg
 func (msg MsgUnjail) Route() string { return RouterKey }
 

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -63,7 +63,13 @@ func ValidateTransaction(ctx sdk.Ctx, k Keeper, stdTx types.StdTx, params Params
 		return nil, types.ErrDuplicateTx(ModuleName, hex.EncodeToString(txHash))
 	}
 
+	// Please note that GetSigners() is simply redirected to Msg.GetSigners()
+	// and does not return the actual signer of this transaction in order to
+	// prevent transactions from being accepted unconditionally.
+	// If you want to allow a transaction signed by an address that is not
+	// included in this return value, add a specific condition case by case.
 	validSigners := stdTx.GetSigners()
+
 	if k.Cdc.IsAfterNonCustodialUpgrade(ctx.BlockHeight()) &&
 		k.Cdc.IsAfterOutputAddressEditorUpgrade(ctx.BlockHeight()) {
 		// MsgStake may be signed by the current output address.  We need to ask

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -13,6 +13,7 @@ import (
 type Keeper struct {
 	Cdc       *codec.Codec
 	POSKeeper types.PosKeeper
+	AppKeeper types.AppKeeper
 	storeKey  sdk.StoreKey
 	subspace  sdk.Subspace
 	permAddrs map[string]types.PermissionsForAddress

--- a/x/auth/types/expectedKeepers.go
+++ b/x/auth/types/expectedKeepers.go
@@ -7,3 +7,7 @@ import (
 type PosKeeper interface {
 	GetMsgStakeOutputSigner(sdk.Ctx, sdk.Msg) sdk.Address
 }
+
+type AppKeeper interface {
+	IsMsgAppTransfer(sdk.Ctx, sdk.Address, sdk.Msg) bool
+}


### PR DESCRIPTION
The patch implements [PIP-35](https://forum.pokt.network/t/pip-35-introduce-a-secure-way-to-transfer-a-staked-app-to-a-new-account/4806), allowing the existing AppMsgStake transaction to change the address of a staked app.  This enables us to *transfer* the existing app slot from one to a new account without unstaking.  To make this operation easier, this patch also introduces a new command `app transfer`.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 15 Dec 23 11:53 UTC
This pull request includes changes in multiple files. Here is a summary of the changes:

1. The file `appStateChanges_test.go` has changes related to application state changes and transfers. The changes include the addition of new import statements, test functions, and helper functions.

2. The file `types.go` has changes related to the `MsgStake` type. The changes involve adding a new method `IsValidTransfer` to check for a special case in the `MsgStake` type where ownership transfer is being done.

3. The file `codec.go` has changes related to the support of an "App Transfer" feature. The changes include adding a constant and a new function for checking if a certain upgrade has occurred.

4. The file `expectedKeepers.go` has changes related to the addition of a new interface `AppKeeper`.

5. The file `keeper.go` has changes that involve adding a new field to the `Keeper` struct.

6. The file `baseapp.go` has changes that include formatting changes in the package comment and modifications in the `DeliverTx` function.

7. The file `app.go` has changes related to the assignment of a field in the `app.accountKeeper` object.

8. The file `auth.go` has changes that include adding comments and conditions for non-custodial and output address editor upgrades.

9. The file `common_test.go` has changes that involve importing packages, renaming a package, and adding/modifying functions.

10. The file `appStateChanges.go` has changes related to the validation and transfer functionality of applications.

11. The file `txUtil.go` has changes that add a new function for transferring an application.

12. The file `app/cmd/cli/app.go` has changes related to the addition of a new command for transferring the ownership of a staked app.

13. The file `keeper.go` has changes that add a new method for checking if a message is for transferring ownership.

14. The file `handler.go` has changes that include import statements, function parameter modifications, and logic for transferring application ownership.

These are the summaries of the changes in each file. Let me know if you have any specific questions or need further information regarding these changes.
<!-- reviewpad:summarize:end -->
