### PR TITLE
Upgrade Go version to 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   # TODO: Make builds for all platforms where Pocket Core is expected to run
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
         environment:
           GO111MODULE: "on"
     resource_class: medium+
@@ -35,7 +35,7 @@ jobs:
   # TODO: Expand the testing capabilities
   test:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
         environment:
           GO111MODULE: "on"
     working_directory: /home/circleci/go/src/github.com/pokt-network/pocket-core
@@ -52,7 +52,7 @@ jobs:
   # Job to trigger the Pocket Core deployments CI with a specific branch
   trigger-pocket-core-deployments-branches:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
         environment:
           GO111MODULE: "on"
     working_directory: /home/circleci/go/src/github.com/pokt-network/pocket-core
@@ -67,11 +67,11 @@ jobs:
       # Trigger Pocket Core deployments CI
       - run:
           name: Trigger Pocket Core Deployment build using branch.
-          command: "sh .circleci/trigger.sh ${POCKET_CORE_DEPLOYMENTS_TRIGGER_API_KEY} ${CIRCLE_BRANCH} 1.18 staging"
+          command: "sh .circleci/trigger.sh ${POCKET_CORE_DEPLOYMENTS_TRIGGER_API_KEY} ${CIRCLE_BRANCH} 1.21 staging"
   # Job to trigger the Pocket Core deployments CI with a specific tag
   trigger-pocket-core-deployments-tags:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
         environment:
           GO111MODULE: "on"
     working_directory: /home/circleci/go/src/github.com/pokt-network/pocket-core
@@ -86,7 +86,7 @@ jobs:
       # Trigger Pocket Core deployments CI
       - run:
           name: Trigger Pocket Core Deployment build using tags.
-          command: "sh .circleci/trigger.sh ${POCKET_CORE_DEPLOYMENTS_TRIGGER_API_KEY} ${CIRCLE_TAG} 1.18 staging"
+          command: "sh .circleci/trigger.sh ${POCKET_CORE_DEPLOYMENTS_TRIGGER_API_KEY} ${CIRCLE_TAG} 1.21 staging"
 
 # Workflow definitions
 workflows:

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,7 +1,7 @@
 # Based on a previous implementation to make sure we don't break existing deployments.
 # https://github.com/pokt-network/pocket-core-deployments/blob/staging/docker/Dockerfile
 
-FROM golang:1.17-alpine as build
+FROM golang:1.21-alpine as build
 RUN apk add --no-cache ca-certificates
 WORKDIR /build
 ADD . .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Within your fork you are free to work however you want, but keep in mind that in
 
 #### Setting up the Go Environment
 
-Please follow the [Official Installation Guide](https://go.dev/doc/install) to complete this step. Pocket Core uses `go 1.18` so make sure to install the appropiate version before beginning development.
+Please follow the [Official Installation Guide](https://go.dev/doc/install) to complete this step. Pocket Core uses `go 1.21` so make sure to install the appropiate version before beginning development.
 
 #### Installing dependencies
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Official golang implementation of the Pocket Network Protocol.
 <div>
   <a href="https://godoc.org/github.com/pokt-network/pocket-core"><img src="https://img.shields.io/badge/godoc-reference-blue.svg"/></a>
   <a href="https://goreportcard.com/report/github.com/pokt-network/pocket-core"><img src="https://goreportcard.com/badge/github.com/pokt-network/pocket-core"/></a>
-  <a href="https://golang.org"><img  src="https://img.shields.io/badge/golang-v1.18-red.svg"/></a>
+  <a href="https://golang.org"><img  src="https://img.shields.io/badge/golang-v1.21-red.svg"/></a>
   <a href="https://github.com/tools/godep" ><img src="https://img.shields.io/badge/godep-dependency-71a3d9.svg"/></a>
 </div>
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pokt-network/pocket-core
 
-go 1.18
+go 1.21
 
 replace github.com/tendermint/tendermint => github.com/pokt-network/tendermint v0.32.11-0.20230426215212-59310158d3e9
 

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
+github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/Workiva/go-datastructures v1.0.52 h1:PLSK6pwn8mYdaoaCZEMsXBpBotr4HHn9abU0yMQt0NI=
 github.com/Workiva/go-datastructures v1.0.52/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -61,6 +62,7 @@ github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13P
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
+github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
@@ -115,6 +117,7 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQD
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
The coming patch #1581 uses Go Generics that is available since Go 1.18. Since .github/workflows/Dockerfile pulls a container with Go 1.17, that patch breaks CI workflow.  This patch upgrades Go version in all CI workflows to the latest version 1.21.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Dec 23 08:47 UTC
This pull request upgrades the Go version in all CI workflows to version 1.21. The current version 1.18 is causing issues with the coming patch that uses Go Generics available since Go 1.18. The upgrade is done in the .circleci/config.yml file for the build, test, and trigger-pocket-core-deployments-branches sections. It is also done in the .github/workflows/Dockerfile file. Additionally, the go.mod and README.md files are updated to reflect the new Go version. The patch includes a total of 13 insertions and 10 deletions across 6 files.
<!-- reviewpad:summarize:end -->
