### PR TITLE
Do not call `node.GetChains()` if node is nil

### DIFF
--- a/x/pocketcore/types/session.go
+++ b/x/pocketcore/types/session.go
@@ -150,10 +150,9 @@ func NewSessionNodes(
 
 		// cross check the node from the `new` or `end` world state
 		node = keeper.Validator(ctx, n)
-		lenNodeChains := int64(len(node.GetChains()))
 		// if not found or jailed or is overstaked to chains
 		if node == nil ||
-			(isEnforceMaxChains && lenNodeChains > nodeMaxChains) ||
+			(isEnforceMaxChains && int64(len(node.GetChains())) > nodeMaxChains) ||
 			node.IsJailed() ||
 			!NodeHasChain(chain, node) ||
 			sessionNodes.Contains(node.GetAddress()) {


### PR DESCRIPTION
In `NewSessionNodes`, the variable `node` can be `nil` if the node is unstaked between `sessionCtx` and `ctx`.  In such a case, `node.GetChains()` causes a panic.  This patch makes sure we don't call it if the `node` is `nil`.
This is a regression from #1582.

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Dec 23 10:23 UTC
This pull request fixes a regression introduced in #1582. The patch ensures that the function `node.GetChains()` is not called if the `node` is `nil`, preventing a panic in the `NewSessionNodes` function.
<!-- reviewpad:summarize:end -->
