### PR TITLE
Docker Image enhancement and better CLI support.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# this is not need on context
+.circleci
+# only workflow files that could be needed on the image should be added to the context
+!.github/workflows
+# ide
+.editorconfig
+# doc files
+doc
+docs
+.gitbook.yaml
+reviewpad.yml
+CONTRIBUTING.md
+LICENSE.md
+README.md
+# images
+**/*.png

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -8,11 +8,31 @@ ADD . .
 RUN go build -o pocket app/cmd/pocket_core/main.go
 
 FROM alpine
-RUN apk add --update --no-cache expect bash leveldb-dev tzdata && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
+RUN apk add --update --no-cache expect bash leveldb-dev tzdata curl \
+    && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
     && addgroup --gid 1001 -S app \
     && adduser --uid 1005 -S -G app app
+
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /build/pocket /bin/pocket
 COPY .github/workflows/entrypoint.sh /home/app/entrypoint.sh
-RUN chown -R app /bin/pocket && mkdir -p /home/app/.pocket/config && chown -R app /home/app/.pocket
+# allow users to run the container as root and fix the permissions in an easy way
+# this could be used as a one time run entrypoint.
+# e.g:
+# docker-compose:
+#   entrypoint: [ "/home/app/fix_permissions.sh", "/home/app/.pocket"]
+#   user: root
+# docker:
+#   --entrypoint="/home/app/fix_permissions.sh /home/app/.pocket" -u root
+COPY .github/workflows/fix_permissions.sh /home/app/fix_permissions.sh
+
+RUN chmod +x /home/app/entrypoint.sh && \
+    chmod +x /home/app/fix_permissions.sh && \
+    chown -R app /bin/pocket \
+    && mkdir -p /home/app/.pocket/config \
+    && chown -R app /home/app/.pocket
+
+# run the container as app user instead of root
+USER app
+
 ENTRYPOINT ["/usr/bin/expect", "/home/app/entrypoint.sh"]

--- a/.github/workflows/fix_permissions.sh
+++ b/.github/workflows/fix_permissions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+datadir=$1
+echo "Attempting to fix ${datadir} permissions to be own by app:app"
+chown -R app:app $datadir
+echo "${datadir} permissions applied."
+echo "Please turn off entrypoint override and ensure you are using user app or user 1005 when start container."
+exit 0


### PR DESCRIPTION
#### Why?

A few Geo-Mesh users report to POKTscan about an issue with the new image after we adopt the one on the pokt-network/pocket-core repository on the latest RC.

They report that this image is using `root` as the user and is recommended to avoid that practice. There are a lot of blogs and documentation about this, [here](https://docs.bitnami.com/tutorials/why-non-root-containers-are-important-for-security) one of them from a well-known docker image user/company.

Also, we detected a few things that could be enhanced on both, entry point and docker context.

The problem with having a public image using root right now is that pocket binary generates folders and files that now belong to the `root` user, so they will need to modify those permissions to belong to the proper `app` user and group. To this, I added another optional entry point that could be used once to fix the permission issue and then start the container as before.

[Here](https://github.com/pokt-network/pocket-core/pull/1600/files#diff-8a9d880ecb3d20b3cfe8def4da1bd200fcbd44131caee95ea699a34faf9cfd6fR19) you can see how to use it with docker-compose or docker

#### Changes:

- Modifications to Dockerfile allow the container to run as `app` user instead of `root`.
- Added a new shell script named fix_permissions.sh to fix ownership issues related to running containers.
- Updated Dockerfile to use this new script.
- Added a .dockerignore file to help maintain a cleaner Docker build context, excluding unnecessary files. 
- Modifications to entrypoint.sh allows the user to run all its internal commands with the proper --datadir param. Now properly handle the start command when --keybase=false is sent. Also, allow the user to pass the --datadir as an env variable to omit it on the start command.

reviewpad:summary
