### PR TITLE
[DRAFT] Enable Session Create w/ Insufficient Servicer Count

### DIFF
--- a/x/apps/keeper/appStateChanges.go
+++ b/x/apps/keeper/appStateChanges.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tendermint/tendermint/libs/strings"
+
 	"github.com/pokt-network/pocket-core/crypto"
 	sdk "github.com/pokt-network/pocket-core/types"
 	"github.com/pokt-network/pocket-core/x/apps/types"
-	"github.com/tendermint/tendermint/libs/strings"
 )
 
 func ensurePubKeyTypeSupported(
@@ -45,6 +46,8 @@ func ensurePubKeyTypeSupported(
 func (k Keeper) ValidateApplicationStaking(ctx sdk.Ctx, application types.Application, amount sdk.BigInt) sdk.Error {
 	// convert the amount to sdk.Coin
 	coin := sdk.NewCoins(sdk.NewCoin(k.StakeDenom(ctx), amount))
+	// TODO_IN_THIS_PR: Related to gateways having a limit on num chains.
+	// Validate the number of chains that can be staked for
 	if int64(len(application.Chains)) > k.MaxChains(ctx) {
 		return types.ErrTooManyChains(types.ModuleName)
 	}

--- a/x/apps/keeper/appStateChanges.go
+++ b/x/apps/keeper/appStateChanges.go
@@ -46,7 +46,6 @@ func ensurePubKeyTypeSupported(
 func (k Keeper) ValidateApplicationStaking(ctx sdk.Ctx, application types.Application, amount sdk.BigInt) sdk.Error {
 	// convert the amount to sdk.Coin
 	coin := sdk.NewCoins(sdk.NewCoin(k.StakeDenom(ctx), amount))
-	// TODO_IN_THIS_PR: Related to gateways having a limit on num chains.
 	// Validate the number of chains that can be staked for
 	if int64(len(application.Chains)) > k.MaxChains(ctx) {
 		return types.ErrTooManyChains(types.ModuleName)

--- a/x/pocketcore/keeper/claim.go
+++ b/x/pocketcore/keeper/claim.go
@@ -182,7 +182,6 @@ func (k Keeper) ValidateClaim(ctx sdk.Ctx, claim pc.MsgClaim) (err sdk.Error) {
 		}
 	}
 	// Ensure that the app is not staked to more than the permitted number of chains
-	// TODO_IN_THIS_PR: Related to gateways having a limit on num chains.
 	lenAppChains := int64(len(app.GetChains()))
 	if pc.ModuleCdc.IsAfterEnforceMaxChainsUpgrade(ctx.BlockHeight()) &&
 		lenAppChains > k.appKeeper.MaxChains(sessionContext) {

--- a/x/pocketcore/keeper/claim.go
+++ b/x/pocketcore/keeper/claim.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tendermint/tendermint/rpc/client"
+
 	"github.com/pokt-network/pocket-core/codec"
 	"github.com/pokt-network/pocket-core/crypto"
 	sdk "github.com/pokt-network/pocket-core/types"
 	"github.com/pokt-network/pocket-core/x/auth"
 	"github.com/pokt-network/pocket-core/x/auth/util"
 	pc "github.com/pokt-network/pocket-core/x/pocketcore/types"
-	"github.com/tendermint/tendermint/rpc/client"
 )
 
 // "SendClaimTx" - Automatically sends a claim of work/challenge based on relays or challenges stored.
@@ -181,6 +182,7 @@ func (k Keeper) ValidateClaim(ctx sdk.Ctx, claim pc.MsgClaim) (err sdk.Error) {
 		}
 	}
 	// Ensure that the app is not staked to more than the permitted number of chains
+	// TODO_IN_THIS_PR: Related to gateways having a limit on num chains.
 	lenAppChains := int64(len(app.GetChains()))
 	if pc.ModuleCdc.IsAfterEnforceMaxChainsUpgrade(ctx.BlockHeight()) &&
 		lenAppChains > k.appKeeper.MaxChains(sessionContext) {

--- a/x/pocketcore/types/errors.go
+++ b/x/pocketcore/types/errors.go
@@ -95,6 +95,7 @@ const (
 	CodeInvalidMerkleRangeError          = 89
 	CodeEvidenceSealed                   = 90
 	CodeChainsOverLimitError             = 91
+	CodeZeroNodesError                   = 92
 )
 
 var (
@@ -126,6 +127,7 @@ var (
 	EmptyNonNativeChainError         = errors.New("the non-native chain is of Length 0")
 	EmptyBlockIDError                = errors.New("the block addr is of Length 0")
 	InsufficientNodesError           = errors.New("there are less than the minimum session nodes found")
+	NoNodesError                     = errors.New("there are zero session nodes found")
 	EmptySessionKeyError             = errors.New("the session key passed is of Length 0")
 	MismatchedByteArraysError        = errors.New("the byte arrays are not of the same Length")
 	FilterNodesError                 = errors.New("unable to filter nodes: ")
@@ -448,6 +450,10 @@ func NewEmptyNonNativeChainError(codespace sdk.CodespaceType) sdk.Error {
 
 func NewInsufficientNodesError(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInsufficientNodesError, InsufficientNodesError.Error())
+}
+
+func NewZeroNodesError(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeZeroNodesError, InsufficientNodesError.Error())
 }
 
 func NewInvalidSessionError(codespace sdk.CodespaceType) sdk.Error {

--- a/x/pocketcore/types/service.go
+++ b/x/pocketcore/types/service.go
@@ -68,7 +68,6 @@ func (r *Relay) Validate(
 		return sdk.ZeroInt(), NewAppNotFoundError(ModuleName)
 	}
 	// Ensure that the app is not staked for more than the permitted number of chains
-	// TODO_IN_THIS_PR: Related to gateways having a limit on num chains.
 	numAppChains := int64(len(app.GetChains()))
 	if ModuleCdc.IsAfterEnforceMaxChainsUpgrade(ctx.BlockHeight()) &&
 		numAppChains > appsKeeper.MaxChains(sessionCtx) {

--- a/x/pocketcore/types/service.go
+++ b/x/pocketcore/types/service.go
@@ -67,7 +67,8 @@ func (r *Relay) Validate(
 	if !found {
 		return sdk.ZeroInt(), NewAppNotFoundError(ModuleName)
 	}
-	// Ensure that the app is not staked to more than the permitted number of chains
+	// Ensure that the app is not staked for more than the permitted number of chains
+	// TODO_IN_THIS_PR: Related to gateways having a limit on num chains.
 	numAppChains := int64(len(app.GetChains()))
 	if ModuleCdc.IsAfterEnforceMaxChainsUpgrade(ctx.BlockHeight()) &&
 		numAppChains > appsKeeper.MaxChains(sessionCtx) {

--- a/x/pocketcore/types/session.go
+++ b/x/pocketcore/types/session.go
@@ -122,8 +122,8 @@ func NewSessionNodes(
 	// all nodesAddrs at session genesis
 	nodesAddrs, totalNodes := keeper.GetValidatorsByChain(sessionCtx, chain)
 	// validate nodesAddrs
-	if totalNodes < sessionNodesCount {
-		return nil, NewInsufficientNodesError(ModuleName)
+	if totalNodes <= 0 {
+		return nil, NewZeroNodesError(ModuleName)
 	}
 	sessionNodes = make(SessionNodes, sessionNodesCount)
 	var node exported.ValidatorI


### PR DESCRIPTION
## Description

This is a WIP demo PR to consider enabling session creation even if the number of nodes in a session is insufficient.

Example 1:
1. SessionNodeCount is 24
2. 1 Supplier is staked for a chain
3. Session will still be created with 1 supplier

Example 2:
1. SessionNodeCount is 24
2. 50 Supplier are staked for a chain
3. Session will be created with a pseudorandom set of 24 suppliers, as always.
