### PR TITLE
Add pwd flags to appTransferCmd

### DIFF
--- a/app/cmd/cli/app.go
+++ b/app/cmd/cli/app.go
@@ -35,6 +35,7 @@ func init() {
 	appStakeCmd.Flags().StringVar(&pwd, "pwd", "", "passphrase used by the cmd, non empty usage bypass interactive prompt")
 	appUnstakeCmd.Flags().StringVar(&pwd, "pwd", "", "passphrase used by the cmd, non empty usage bypass interactive prompt")
 	createAATCmd.Flags().StringVar(&pwd, "pwd", "", "passphrase used by the cmd, non empty usage bypass interactive prompt")
+	appTransferCmd.Flags().StringVar(&pwd, "pwd", "", "passphrase used by the cmd, non empty usage bypass interactive prompt")
 }
 
 var appStakeCmd = &cobra.Command{


### PR DESCRIPTION
Enable running `pocket apps transfer` with the `--pwd` flag so it can be automated.