### PR TITLE
Version bump to RC-0.12.0

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	AppVersion = "RC-0.11.1"
+	AppVersion = "RC-0.12.0"
 )
 
 // NewPocketCoreApp is a constructor function for PocketCoreApp


### PR DESCRIPTION
Due to a consensus breaking change to fix a regression in RC-0.11.1 (#1614), this patch is upgrading the protocol version to RC-0.12.0.  That regression caused the chainhalt in the testnet at height block.  We're rolling back the testnet to recover it.  This version bump helps to make sure all validators are runing the latest version.

reviewpad:summary
