### PR TITLE
fix: fix slice init length

### DIFF
--- a/store/rootmulti/heightcache/memorycache.go
+++ b/store/rootmulti/heightcache/memorycache.go
@@ -108,7 +108,7 @@ func (m MemoryCache) Commit(height int64) {
 	m.pastHeights[lowestIdx].height = m.current.height
 	m.pastHeights[lowestIdx].data = map[string]string{}
 
-	orderedKeys := make([]string, len(m.current.data))
+	orderedKeys := make([]string, 0, len(m.current.data))
 	for k, v := range m.current.data {
 		m.pastHeights[lowestIdx].data[k] = v
 		orderedKeys = append(orderedKeys, k)


### PR DESCRIPTION
## Description

The intention here should be to initialize a slice with a capacity of  `len(m.current.data)` rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW
