### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/store/iavl/node.go
+++ b/store/iavl/node.go
@@ -418,7 +418,7 @@ func (node *Node) getRightNode(t *ImmutableTree) *Node {
 
 // NOTE: mutates height and size
 func (node *Node) calcHeightAndSize(t *ImmutableTree) {
-	node.height = maxInt8(node.getLeftNode(t).height, node.getRightNode(t).height) + 1
+	node.height = max(node.getLeftNode(t).height, node.getRightNode(t).height) + 1
 	node.size = node.getLeftNode(t).size + node.getRightNode(t).size
 }
 

--- a/store/iavl/util.go
+++ b/store/iavl/util.go
@@ -24,13 +24,6 @@ func debug(format string, args ...interface{}) {
 	}
 }
 
-func maxInt8(a, b int8) int8 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Returns a slice of the same length (big endian)
 // except incremented by one.
 // Appends 0x00 if bz is all 0xFF.

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -98,20 +98,6 @@ func TestIdentInt(t *testing.T) {
 	}
 }
 
-func minint(i1, i2 int64) int64 {
-	if i1 < i2 {
-		return i1
-	}
-	return i2
-}
-
-func maxint(i1, i2 int64) int64 {
-	if i1 > i2 {
-		return i1
-	}
-	return i2
-}
-
 func TestArithInt(t *testing.T) {
 	for d := 0; d < 1000; d++ {
 		n1 := int64(rand.Int31())
@@ -131,8 +117,8 @@ func TestArithInt(t *testing.T) {
 			{i1.SubRaw(n2), n1 - n2},
 			{i1.MulRaw(n2), n1 * n2},
 			{i1.QuoRaw(n2), n1 / n2},
-			{MinInt(i1, i2), minint(n1, n2)},
-			{MaxInt(i1, i2), maxint(n1, n2)},
+			{min(i1, i2), min(n1, n2)},
+			{max(i1, i2), max(n1, n2)},
 			{i1.Neg(), -n1},
 		}
 
@@ -163,20 +149,6 @@ func TestCompInt(t *testing.T) {
 			require.Equal(t, tc.nres, tc.ires, "BigInt comparison operation does not match with int64 operation. tc #%d", tcnum)
 		}
 	}
-}
-
-func minuint(i1, i2 uint64) uint64 {
-	if i1 < i2 {
-		return i1
-	}
-	return i2
-}
-
-func maxuint(i1, i2 uint64) uint64 {
-	if i1 > i2 {
-		return i1
-	}
-	return i2
 }
 
 func randint() BigInt {


### PR DESCRIPTION
## Description

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max